### PR TITLE
Status page password handling fixes

### DIFF
--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -190,6 +190,8 @@ func statusPageCreate(ctx context.Context, d *schema.ResourceData, meta interfac
 		return err
 	}
 	d.SetId(out.Data.ID)
+	// Set password from user input since it's not included in the API response
+	d.Set("password", in.Password)
 	return statusPageCopyAttrs(d, &out.Data.Attributes)
 }
 
@@ -207,6 +209,10 @@ func statusPageRead(ctx context.Context, d *schema.ResourceData, meta interface{
 func statusPageCopyAttrs(d *schema.ResourceData, in *statusPage) diag.Diagnostics {
 	var derr diag.Diagnostics
 	for _, e := range statusPageRef(in) {
+		if e.k == "password" {
+			// Skip copying password as it's never returned from the API
+			continue
+		}
 		if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -106,6 +106,7 @@ var statusPageSchema = map[string]*schema.Schema{
 		Description: "Set a password of your status page (we won't store it as plaintext, promise). Required when password_enabled: true. We will set password_enabled: false automatically when you send us an empty password.",
 		Type:        schema.TypeString,
 		Optional:    true,
+		Sensitive:   true,
 	},
 }
 

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -35,12 +35,14 @@ func TestResourceStatusPage(t *testing.T) {
 				    company_url  = "https://example.com"
 				    timezone     = "UTC"
 				    subdomain    = "%s"
+				    password     = "secret123"
 				}
 				`, subdomain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_status_page.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "subdomain", subdomain),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "timezone", "UTC"),
+					resource.TestCheckResourceAttr("betteruptime_status_page.this", "password", "secret123"),
 				),
 			},
 			// Step 2 - update.
@@ -55,12 +57,14 @@ func TestResourceStatusPage(t *testing.T) {
 				    company_url  = "https://example.com"
 				    timezone     = "America/Los_Angeles"
 				    subdomain    = "%s"
+				    password     = "secret1234"
 				}
 				`, subdomain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_status_page.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "subdomain", subdomain),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "timezone", "America/Los_Angeles"),
+					resource.TestCheckResourceAttr("betteruptime_status_page.this", "password", "secret1234"),
 				),
 			},
 			// Step 3 - make no changes, check plan is empty.
@@ -75,6 +79,7 @@ func TestResourceStatusPage(t *testing.T) {
 				    company_url  = "https://example.com"
 				    timezone     = "America/Los_Angeles"
 				    subdomain    = "%s"
+				    password     = "secret1234"
 				}
 				`, subdomain),
 				PlanOnly: true,

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -89,6 +89,8 @@ func TestResourceStatusPage(t *testing.T) {
 				ResourceName:      "betteruptime_status_page.this",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// Password can't be imported and must be ignored when verifying imported state
+				ImportStateVerifyIgnore: []string{"password"},
 			},
 		},
 	})

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestResourceStatusPage(t *testing.T) {
-	server := newResourceServer(t, "/api/v2/status-pages", "1")
+	server := newResourceServer(t, "/api/v2/status-pages", "1", "password")
 	defer server.Close()
 
 	var subdomain = "example"


### PR DESCRIPTION
This PR attempts to fix two issues I found with the `betteruptime_status_page` resource:

1. `password` is not marked sensitive and shows up in the output
1. Running `terraform plan` for any status page with a `password` will always try to update it even if the password hasn't changed

The cause for the latter issue seems to be the fact that the `/api/v2/status-pages/{id}` APIs (POST, PATCH, GET) never return the `password` once it's set, and this causes an empty password to be stored in the state. You can actually see this as a warning in the debug logs after `apply`ing changes:

```
    The following problems may be the cause of any confusing errors from downstream operations:
      - .password: was cty.StringVal("foobar123"), but now cty.StringVal("")
```

And here's the plan (before this PR) for the situation where the password hasn't actually changed:

```
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # betteruptime_status_page.test has been changed
  ~ resource "betteruptime_status_page" "test" {
        id                         = "..."
      - password                   = "foobar123" -> null
        # (9 unchanged attributes hidden)
    }

...

Terraform will perform the following actions:

  # betteruptime_status_page.test will be updated in-place
  ~ resource "betteruptime_status_page" "test" {
        id                         = "..."
      + password                   = "foobar123"
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

In order to test the latter case, the test server can now be instructed not to echo back certain fields, so the functionality corresponds to the real-world API.

I tested `plan`, `apply` and `import` with these changes and everything seemed to work as expected.