### PR TITLE
Return heartbeat URL as output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,15 +93,15 @@ terraform: install
 
 build:
 # -gcflags "all=-N -l" is here for delve (`go tool compile -help` for more)
-	go build -gcflags "all=-N -l" -ldflags "-X main.version=0.0.0-0"
+	go build -gcflags "all=-N -l" -ldflags "-X main.version=0.3.6"
 
 install: build
-	PLUGIN_DIR="$$HOME/.terraform.d/plugins/registry.terraform.io/BetterStackHQ/better-uptime/0.0.0-0/$$(go env GOOS)_$$(go env GOARCH)" && \
+	PLUGIN_DIR="$$HOME/.terraform.d/plugins/registry.terraform.io/BetterStackHQ/better-uptime/0.3.6/$$(go env GOOS)_$$(go env GOARCH)" && \
 		mkdir -p "$$PLUGIN_DIR" && \
 		cp terraform-provider-better-uptime "$$PLUGIN_DIR/"
 
 uninstall:
-	rm -rf "$$HOME/.terraform.d/plugins/registry.terraform.io/BetterStackHQ/better-uptime/0.0.0-0"
+	rm -rf "$$HOME/.terraform.d/plugins/registry.terraform.io/BetterStackHQ/better-uptime/0.3.6"
 
 debug: build
 # https://github.com/go-delve/delve/blob/master/Documentation/installation/README.md

--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -67,6 +67,7 @@ Monitor lookup.
 - **recovery_period** (Number) How long the monitor must be up to automatically mark an incident as resolved after being down.
 - **regions** (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.
 - **request_body** (String) Request body for POST, PUT, PATCH requests.
+- **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request? In seconds.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - **sms** (Boolean) Should we send an SMS to the on-call person?

--- a/docs/resources/betteruptime_heartbeat.md
+++ b/docs/resources/betteruptime_heartbeat.md
@@ -34,6 +34,7 @@ https://docs.betteruptime.com/api/heartbeats-api
 
 ### Read-Only
 
-- **id** (String) The ID of this Monitor.
+- **id** (String) The ID of this heartbeat.
+- **url** (String) The url of this heartbeat.
 
 

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -66,8 +66,8 @@ https://docs.betteruptime.com/api/monitors-api
 - **recovery_period** (Number) How long the monitor must be up to automatically mark an incident as resolved after being down.
 - **regions** (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.
 - **request_body** (String) Request body for POST, PUT, PATCH requests.
+- **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request? In seconds.
-- **request_headers** (List of Map of strings) An array of request headers to set. Each header should be an object/map with "name" and "value" attributes.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - **sms** (Boolean) Should we send an SMS to the on-call person?
 - **ssl_expiration** (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.

--- a/internal/provider/resource_heartbeat.go
+++ b/internal/provider/resource_heartbeat.go
@@ -12,7 +12,7 @@ import (
 
 var heartbeatSchema = map[string]*schema.Schema{
 	"id": {
-		Description: "The ID of this Monitor.",
+		Description: "The ID of this heartbeat.",
 		Type:        schema.TypeString,
 		Computed:    true,
 	},
@@ -20,6 +20,11 @@ var heartbeatSchema = map[string]*schema.Schema{
 		Description: "A name of the service for this heartbeat.",
 		Type:        schema.TypeString,
 		Required:    true,
+	},
+	"url": {
+		Description: "The url of this heartbeat.",
+		Type:        schema.TypeString,
+		Computed:    true,
 	},
 	"period": {
 		Description: "How often should we expect this heartbeat? In seconds. Minimum value: 30 seconds",
@@ -96,6 +101,7 @@ func newHeartbeatResource() *schema.Resource {
 
 type heartbeat struct {
 	Name             *string `json:"name,omitempty"`
+	Url              *string `json:"url,omitempty"`
 	Period           *int    `json:"period,omitempty"`
 	Grace            *int    `json:"grace,omitempty"`
 	Call             *bool   `json:"call,omitempty"`
@@ -125,6 +131,7 @@ func heartbeatRef(in *heartbeat) []struct {
 		v interface{}
 	}{
 		{k: "name", v: &in.Name},
+		{k: "url", v: &in.Url},
 		{k: "period", v: &in.Period},
 		{k: "grace", v: &in.Grace},
 		{k: "call", v: &in.Call},


### PR DESCRIPTION
We weren't returning the url as a computed attribute before, so it couldn't have been used in outputs.