### PR TITLE
Fix incorrect json marshalling of empty arrays

### DIFF
--- a/internal/provider/ptr.go
+++ b/internal/provider/ptr.go
@@ -26,7 +26,7 @@ func load(d *schema.ResourceData, key string, receiver interface{}) {
 		}
 	case **[]string:
 		if v, ok := d.GetOkExists(key); ok {
-			var t []string
+			var t = make([]string, 0)
 			for _, v := range v.([]interface{}) {
 				t = append(t, v.(string))
 			}
@@ -34,7 +34,7 @@ func load(d *schema.ResourceData, key string, receiver interface{}) {
 		}
 	case **[]int:
 		if v, ok := d.GetOkExists(key); ok {
-			var t []int
+			var t = make([]int, 0)
 			for _, v := range v.([]interface{}) {
 				t = append(t, v.(int))
 			}


### PR DESCRIPTION
When an user would specify an empty array as a value, we would serialize it as a `null` instead of `[]`, due to the value being a nil pointer previously.
Relevant reading: https://apoorvam.github.io/blog/2017/golang-json-marshal-slice-as-empty-array-not-null/