### PR TITLE
U-1324 Fix status page history validation (#86)

### DIFF
--- a/docs/resources/betteruptime_status_page.md
+++ b/docs/resources/betteruptime_status_page.md
@@ -36,7 +36,7 @@ https://betterstack.com/docs/uptime/api/status-pages/
 - **design** (String) Choose between classic and modern status page design. Possible values: 'v1', 'v2'.
 - **google_analytics_id** (String) Specify your own Google Analytics ID if you want to receive hits on your status page.
 - **hide_from_search_engines** (Boolean) Hide your status page from search engines.
-- **history** (Number) Number of days to display on the status page. Minimum 90 days.
+- **history** (Number) Number of days to display on the status page. Minimum 30 days.
 - **layout** (String) Choose usual vertical layout or space-saving horizontal layout. Only applicable when design: v2. Possible values: 'vertical', 'horizontal'.
 - **logo_url** (String) A direct link to your company's logo. The image should be under 20MB in size.
 - **min_incident_length** (Number) If you don't want to display short incidents on your status page, this attribute is for you.

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -23,8 +23,8 @@ var statusPageSchema = map[string]*schema.Schema{
 		Description: "Number of days to display on the status page. Minimum 90 days.",
 		ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 			history := val.(int)
-			if history < 90 {
-				errs = append(errs, fmt.Errorf("%q must be at least 90, got: %d", key, history))
+			if history < 30 {
+				errs = append(errs, fmt.Errorf("%q must be at least 30, got: %d", key, history))
 			}
 			return
 		},


### PR DESCRIPTION
#86

Adjusting the validation to accept the 30 days value as per our API Documentation. 