### PR TITLE
Fix goreleaser workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.2.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.2.0
         with:
-          version: latest
+          version: '~> 1.26'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,6 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
-        name: Switch to v0.9.3
-        run: git checkout v0.9.3
-      -
         name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
         name: Unshallow
         run: git fetch --prune --unshallow
       -
+        name: Switch to v0.9.3
+        run: git checkout v0.9.3
+      -
         name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Our [`goreleaser` Github Action Job fails](https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/runs/9485577325/job/26137840886) now.

---

Seems that we've missed a deprecation notice (see last succeeding [Github Action Job](https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/runs/9361130714/job/25767611508)):

<img width="2153" alt="image" src="https://github.com/BetterStackHQ/terraform-provider-better-uptime/assets/10008612/5370593a-5c3c-42ac-a3d5-6d42e29e1308">
