### PR TITLE
Update URL from betteruptime.com to uptime.betterstack.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.10.0
+VERSION := 0.10.1
 .PHONY: test build
 
 help:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-provider-better-uptime [![build](https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/workflows/build.yml) [![documentation](https://img.shields.io/badge/-documentation-blue)](https://registry.terraform.io/providers/BetterStackHQ/better-uptime/latest/docs)
 
-Terraform (0.13+) provider for [Better Uptime](https://betteruptime.com/).
+Terraform (0.13+) provider for [Better Uptime](https://uptime.betterstack.com/).
 
 ## Installation
 

--- a/docs/resources/betteruptime_status_page.md
+++ b/docs/resources/betteruptime_status_page.md
@@ -27,7 +27,7 @@ https://betterstack.com/docs/uptime/api/status-pages/
 - **announcement** (String) Add an announcement to your status page.
 - **announcement_embed_css** (String) Modify the design of the announcement embed.
 - **announcement_embed_link** (String) Point your embedded announcement to a specified URL.
-- **announcement_embed_visible** (Boolean) Toggle this field if you want to show an announcement in your embed. You can embed the announcement using this snippet: `<script src="https://betteruptime.com/widgets/announcement.js" data-id="<SET STATUS_PAGE_ID>" async="async" type="text/javascript"></script>`
+- **announcement_embed_visible** (Boolean) Toggle this field if you want to show an announcement in your embed. You can embed the announcement using this snippet: `<script src="https://uptime.betterstack.com/widgets/announcement.js" data-id="<SET STATUS_PAGE_ID>" async="async" type="text/javascript"></script>`
 - **automatic_reports** (Boolean) Generate automatic reports when your services go down
 - **contact_url** (String) URL that should be used for contacting you in case of an emergency.
 - **custom_css** (String) Unleash your inner designer and tweak our status page design to fit your branding.

--- a/internal/provider/data_incoming_webhook_test.go
+++ b/internal/provider/data_incoming_webhook_test.go
@@ -22,9 +22,9 @@ func TestDataIncomingWebhook(t *testing.T) {
 
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=1":
-			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name": "Incoming Webhook 1", "url":"https://betteruptime.com/api/v1/incoming-webhook/abc","recovery_period":3, "team_wait":60}}],"pagination":{"next":"..."}}`))
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name": "Incoming Webhook 1", "url":"https://uptime.betterstack.com/api/v1/incoming-webhook/abc","recovery_period":3, "team_wait":60}}],"pagination":{"next":"..."}}`))
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=2":
-			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"name": "Incoming Webhook 2", "url":"https://betteruptime.com/api/v1/incoming-webhook/def","recovery_period":4, "team_wait":120}}],"pagination":{"next":null}}`))
+			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"name": "Incoming Webhook 2", "url":"https://uptime.betterstack.com/api/v1/incoming-webhook/def","recovery_period":4, "team_wait":120}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
 		}
@@ -56,7 +56,7 @@ func TestDataIncomingWebhook(t *testing.T) {
 					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "name", name),
 					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "recovery_period", "4"),
 					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "team_wait", "120"),
-					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "url", "https://betteruptime.com/api/v1/incoming-webhook/def"),
+					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "url", "https://uptime.betterstack.com/api/v1/incoming-webhook/def"),
 				),
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,7 +30,7 @@ func WithVersion(v string) Option {
 
 func New(opts ...Option) *schema.Provider {
 	spec := provider{
-		url: "https://betteruptime.com",
+		url: "https://uptime.betterstack.com",
 	}
 	for _, opt := range opts {
 		opt(&spec)

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -115,7 +115,7 @@ var statusPageSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Computed:    true,
-		Description: strings.ReplaceAll(`Toggle this field if you want to show an announcement in your embed. You can embed the announcement using this snippet: **<script src="https://betteruptime.com/widgets/announcement.js" data-id="<SET STATUS_PAGE_ID>" async="async" type="text/javascript"></script>**`, "**", "`"),
+		Description: strings.ReplaceAll(`Toggle this field if you want to show an announcement in your embed. You can embed the announcement using this snippet: **<script src="https://uptime.betterstack.com/widgets/announcement.js" data-id="<SET STATUS_PAGE_ID>" async="async" type="text/javascript"></script>**`, "**", "`"),
 	},
 	"announcement_embed_link": {
 		Description: "Point your embedded announcement to a specified URL.",


### PR DESCRIPTION
Looks like we still have the legacy URL in code... Still keeping `*.betteruptime.com` in status page URLs.

Resolves https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/60#issuecomment-2044712218