### PR TITLE
Ensure fatal error in tests makes the test fail

### DIFF
--- a/internal/provider/data_incoming_webhook_test.go
+++ b/internal/provider/data_incoming_webhook_test.go
@@ -16,6 +16,7 @@ func TestDataIncomingWebhook(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/incoming-webhooks"
@@ -27,6 +28,7 @@ func TestDataIncomingWebhook(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"name": "Incoming Webhook 2", "url":"https://uptime.betterstack.com/api/v1/incoming-webhook/def","recovery_period":4, "team_wait":120}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()

--- a/internal/provider/data_monitor_test.go
+++ b/internal/provider/data_monitor_test.go
@@ -17,6 +17,7 @@ func TestDataMonitor(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/monitors"
@@ -28,6 +29,7 @@ func TestDataMonitor(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"url":"http://example.com","monitor_type":"status"}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()

--- a/internal/provider/data_on_call_calendar_test.go
+++ b/internal/provider/data_on_call_calendar_test.go
@@ -16,6 +16,7 @@ func TestOnCallCalendarData(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/on-calls"
@@ -27,6 +28,7 @@ func TestOnCallCalendarData(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id":"456","attributes":{"name":"Secondary","default_calendar":false},"relationships":{"on_call_users":{"data":[{"id":"456789","type":"user"}]}}}],"included":[{"id":"456789","type":"user","attributes":{"first_name":"Jane","last_name":"Doe","email":"jane@example.com","phone_numbers":["+44 808 157 0192"]}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()
@@ -72,6 +74,7 @@ func TestDefaultOnCallCalendarData(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		switch {
@@ -79,6 +82,7 @@ func TestDefaultOnCallCalendarData(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":{"id":"123","attributes":{"name":"Primary","default_calendar":true},"relationships":{"on_call_users":{"data":[{"id":"123456","type":"user"}]}}},"included":[{"id":"123456","type":"user","attributes":{"first_name":"John","last_name":"Smith","email":"john@example.com","phone_numbers":[]}}]}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()

--- a/internal/provider/data_policy_test.go
+++ b/internal/provider/data_policy_test.go
@@ -16,6 +16,7 @@ func TestDataPolicy(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/policies"
@@ -27,6 +28,7 @@ func TestDataPolicy(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"name": "Policy B", "incident_token":"def","repeat_count":4, "repeat_delay":120}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()

--- a/internal/provider/data_severity_test.go
+++ b/internal/provider/data_severity_test.go
@@ -16,6 +16,7 @@ func TestDataSeverity(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/urgencies"
@@ -27,6 +28,7 @@ func TestDataSeverity(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id": "2", "type": "urgency", "attributes":{"name": "Low Severity", "sms": false, "call": false, "email": true, "push": true}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()

--- a/internal/provider/data_slack_integration_test.go
+++ b/internal/provider/data_slack_integration_test.go
@@ -16,6 +16,7 @@ func TestDataSlackIntegration(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/slack-integrations"
@@ -27,6 +28,7 @@ func TestDataSlackIntegration(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id":"2","attributes":{"slack_team_id":"T456789","slack_team_name":"Team2","slack_channel_id":"C456789","slack_channel_name":"#channel2","slack_status":"active","integration_type":"verbose","on_call_notifications":true}}],"pagination":{"next":null}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 	defer server.Close()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -13,6 +13,7 @@ import (
 func TestProvider(t *testing.T) {
 	if err := New().InternalValidate(); err != nil {
 		t.Fatal(err)
+		t.Fail()
 	}
 }
 
@@ -24,6 +25,7 @@ func TestProviderInit(t *testing.T) {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		exptectedUA := "terraform-provider-better-uptime/0.0.0-0"

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -275,6 +275,7 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		prefix := "/api/v2/monitors"
@@ -285,6 +286,7 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			data.Store(body)
 			w.WriteHeader(http.StatusCreated)
@@ -292,6 +294,7 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 			computed := make(map[string]interface{})
 			if err := json.Unmarshal(body, &computed); err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			computed["pronounceable_name"] = "computed_by_betteruptime"
 			if computed["request_headers"] != nil {
@@ -300,6 +303,7 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 			body, err = json.Marshal(computed)
 			if err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, body)))
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"/"+id:
@@ -308,13 +312,16 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			patch := make(map[string]interface{})
 			if err = json.Unmarshal(data.Load().([]byte), &patch); err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			if err = json.Unmarshal(body, &patch); err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			if patch["request_headers"] != nil {
 				patch["request_headers"] = processRequestHeaders(patch["request_headers"].([]interface{}))
@@ -322,6 +329,7 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 			patched, err := json.Marshal(patch)
 			if err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			data.Store(patched)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, patched)))
@@ -330,6 +338,7 @@ func createTestServer(t *testing.T, data *atomic.Value) *httptest.Server {
 			data.Store([]byte(nil))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 }

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -34,6 +34,7 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
+			t.Fail()
 		}
 		ts.mu.Lock()
 		ts.CalledRequests = append(ts.CalledRequests, CalledRequest{Method: r.Method, URL: r.RequestURI, Body: string(body)})
@@ -43,6 +44,7 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+			t.Fail()
 		}
 
 		switch {
@@ -50,6 +52,7 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 			parsedBody := make(map[string]interface{})
 			if err := json.Unmarshal(body, &parsedBody); err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			for _, field := range fieldsNotReturnedFromApi {
 				delete(parsedBody, field)
@@ -57,6 +60,7 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 			body, err = json.Marshal(parsedBody)
 			if err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 
 			data.Store(body)
@@ -68,13 +72,16 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 			patch := make(map[string]interface{})
 			if err = json.Unmarshal(data.Load().([]byte), &patch); err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			if err = json.Unmarshal(body, &patch); err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			patched, err := json.Marshal(patch)
 			if err != nil {
 				t.Fatal(err)
+				t.Fail()
 			}
 			data.Store(patched)
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"data":{"id":%q,"attributes":%s}}`, id, patched)))
@@ -83,6 +90,7 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 			data.Store([]byte(nil))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+			t.Fail()
 		}
 	}))
 


### PR DESCRIPTION
During #91 I found out that `t.Fatal` doesn't make the tests fail, just adds a log which by default doesn't even appear in console on test success.