### PR TITLE
Add support for DNS monitors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.11.0
+VERSION := 0.11.1
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -71,7 +71,7 @@ Monitor lookup.
     `imap` We will check for an IMAP server at the host specified in the url parameter
 (port is required, and can be 143, 993, or both).
 
-    `dns` We will check for an DNS server at the host specified in the url parameter
+    `dns` We will check for a DNS server at the host specified in the url parameter
 (request_body is required, and should contain the domain to query the DNS server with).
 
     `playwright` We will run the scenario defined by playwright_script, identified in the UI by scenario_name

--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -71,6 +71,9 @@ Monitor lookup.
     `imap` We will check for an IMAP server at the host specified in the url parameter
 (port is required, and can be 143, 993, or both).
 
+    `dns` We will check for an DNS server at the host specified in the url parameter
+(request_body is required, and should contain the domain to query the DNS server with).
+
     `playwright` We will run the scenario defined by playwright_script, identified in the UI by scenario_name
 - **paused** (Boolean) Set to true to pause monitoring - we won't notify you about downtime. Set to false to resume monitoring.
 - **paused_at** (String) The time when this monitor was paused.
@@ -82,7 +85,7 @@ Monitor lookup.
 - **recovery_period** (Number) How long the monitor must be up to automatically mark an incident as resolved after being down. In seconds.
 - **regions** (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.
 - **remember_cookies** (Boolean) Set to true to keep cookies when redirecting.
-- **request_body** (String) Request body for POST, PUT, PATCH requests.
+- **request_body** (String) Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).
 - **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request? In seconds.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -44,7 +44,7 @@ https://betterstack.com/docs/uptime/api/monitors/
     `imap` We will check for an IMAP server at the host specified in the url parameter
 (port is required, and can be 143, 993, or both).
 
-    `dns` We will check for an DNS server at the host specified in the url parameter
+    `dns` We will check for a DNS server at the host specified in the url parameter
 (request_body is required, and should contain the domain to query the DNS server with).
 
     `playwright` We will run the scenario defined by playwright_script, identified in the UI by scenario_name

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -44,6 +44,9 @@ https://betterstack.com/docs/uptime/api/monitors/
     `imap` We will check for an IMAP server at the host specified in the url parameter
 (port is required, and can be 143, 993, or both).
 
+    `dns` We will check for an DNS server at the host specified in the url parameter
+(request_body is required, and should contain the domain to query the DNS server with).
+
     `playwright` We will run the scenario defined by playwright_script, identified in the UI by scenario_name
 - **url** (String) URL of your website or the host you want to ping (see monitor_type below).
 
@@ -78,7 +81,7 @@ https://betterstack.com/docs/uptime/api/monitors/
 - **recovery_period** (Number) How long the monitor must be up to automatically mark an incident as resolved after being down. In seconds.
 - **regions** (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.
 - **remember_cookies** (Boolean) Set to true to keep cookies when redirecting.
-- **request_body** (String) Request body for POST, PUT, PATCH requests.
+- **request_body** (String) Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).
 - **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request? In seconds.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -28,18 +28,33 @@ resource "betteruptime_monitor_group" "this" {
   sort_index = 0
 }
 
-resource "betteruptime_monitor" "this" {
+resource "betteruptime_monitor" "status" {
   url              = "https://example.com"
   monitor_type     = "status"
   monitor_group_id = betteruptime_monitor_group.this.id
 }
 
-resource "betteruptime_status_page_resource" "monitor" {
+resource "betteruptime_monitor" "dns" {
+  url          = "1.1.1.1"
+  monitor_type = "dns"
+  request_body = "example.com"
+  monitor_group_id = betteruptime_monitor_group.this.id
+}
+
+resource "betteruptime_status_page_resource" "monitor_status" {
   status_page_id         = betteruptime_status_page.this.id
   status_page_section_id = betteruptime_status_page_section.monitors.id
-  resource_id            = betteruptime_monitor.this.id
+  resource_id            = betteruptime_monitor.status.id
   resource_type          = "Monitor"
   public_name            = "example.com site"
+}
+
+resource "betteruptime_status_page_resource" "monitor_dns" {
+  status_page_id         = betteruptime_status_page.this.id
+  status_page_section_id = betteruptime_status_page_section.monitors.id
+  resource_id            = betteruptime_monitor.dns.id
+  resource_type          = "Monitor"
+  public_name            = "example.com domain"
 }
 
 resource "betteruptime_heartbeat_group" "this" {

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -35,9 +35,9 @@ resource "betteruptime_monitor" "status" {
 }
 
 resource "betteruptime_monitor" "dns" {
-  url          = "1.1.1.1"
-  monitor_type = "dns"
-  request_body = "example.com"
+  url              = "1.1.1.1"
+  monitor_type     = "dns"
+  request_body     = "example.com"
   monitor_group_id = betteruptime_monitor_group.this.id
 }
 

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -86,7 +86,7 @@ var monitorSchema = map[string]*schema.Schema{
     **imap** We will check for an IMAP server at the host specified in the url parameter
 (port is required, and can be 143, 993, or both).
 
-    **dns** We will check for an DNS server at the host specified in the url parameter
+    **dns** We will check for a DNS server at the host specified in the url parameter
 (request_body is required, and should contain the domain to query the DNS server with).
 
     **playwright** We will run the scenario defined by playwright_script, identified in the UI by scenario_name`, "**", "`"),

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TODO: change to map<name, description> and then use to gen monitor_type description
-var monitorTypes = []string{"status", "expected_status_code", "keyword", "keyword_absence", "ping", "tcp", "udp", "smtp", "pop", "imap", "playwright"}
+var monitorTypes = []string{"status", "expected_status_code", "keyword", "keyword_absence", "ping", "tcp", "udp", "smtp", "pop", "imap", "dns", "playwright"}
 var ipVersions = []string{"ipv4", "ipv6"}
 var monitorSchema = map[string]*schema.Schema{
 	"team_name": {
@@ -85,6 +85,9 @@ var monitorSchema = map[string]*schema.Schema{
 
     **imap** We will check for an IMAP server at the host specified in the url parameter
 (port is required, and can be 143, 993, or both).
+
+    **dns** We will check for an DNS server at the host specified in the url parameter
+(request_body is required, and should contain the domain to query the DNS server with).
 
     **playwright** We will run the scenario defined by playwright_script, identified in the UI by scenario_name`, "**", "`"),
 		Type:     schema.TypeString,
@@ -242,7 +245,7 @@ var monitorSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"request_body": {
-		Description: "Request body for POST, PUT, PATCH requests.",
+		Description: "Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,


### PR DESCRIPTION
We currently don't support DNS monitors via Terraform, even though our API supports it.

```
resource "betteruptime_monitor" "dns" {
  url          = "1.1.1.1"
  monitor_type = "dns"
  request_body = "google.com"
}
```

<img width="1029" alt="image" src="https://github.com/BetterStackHQ/terraform-provider-better-uptime/assets/10008612/528e0aa8-a91d-4c19-a2c7-27cd5e7dda27">
