### PR TITLE
Add end-to-end tests for Terraform examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 jobs:
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   e2e_test:
     strategy:
       matrix:
-        terraform-version: [0.13, 1.8.5]
+        terraform-version: [0.13, 0.14, 0.15, 1.0, 1.2, 1.4, 1.6, 1.8]
         config: [examples/basic, examples/advanced, examples/on_call_calendars]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,9 +49,12 @@ jobs:
           BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
       - name: Plan resources via Terraform - must be empty
         run: |
-          make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --detailed-exitcode --input=false"
-          if [ $? -eq 2 ]; then
-            echo "Terraform plan has changes, exiting with error."
+          make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --input=false --out=tfplan"
+          CHANGES="$(terraform -chdir="examples/advanced" show --json tfplan | jq '.resource_changes | length')"
+          if [ "$CHANGES" == "0" ]; then
+            echo "No planned changes detected after first apply. Success!"
+          else
+            echo "$CHANGES planned changes detected after first apply. Failure!"
             exit 1
           fi
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --input=false --out=tfplan"
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="show --json tfplan > tfplan.json"
-          CHANGES="$(jq "[.resource_changes[] | select(.change.actions != ["no-op"])] | length" "${{ matrix.config }}/tfplan.json")"
+          CHANGES="$(jq "[.resource_changes[] | select(.change.actions != [\"no-op\"])] | length" "${{ matrix.config }}/tfplan.json")"
           if [ "$CHANGES" == "0" ]; then
             echo "No planned changes detected after first apply. Success!"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
   e2e_test:
     strategy:
       matrix:
-        terraform-version: [0.14, 1.0, 1.8, latest]
+        terraform-version: ["0.14", "1.0", "1.8", "latest"]
         config: [examples/basic, examples/advanced, examples/on_call_calendars]
       fail-fast: false
     runs-on: ubuntu-latest
@@ -50,7 +50,8 @@ jobs:
       - name: Plan resources via Terraform - must be empty
         run: |
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --input=false --out=tfplan"
-          CHANGES="$(terraform -chdir="examples/advanced" show --json tfplan | jq '.resource_changes | length')"
+          make terraform CONFIGURATION="${{ matrix.config }}" ARGS="show --json tfplan > tfplan.json"
+          CHANGES="$(jq ".resource_changes | length" "${{ matrix.config }}/tfplan.json")"
           if [ "$CHANGES" == "0" ]; then
             echo "No planned changes detected after first apply. Success!"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --input=false --out=tfplan"
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="show --json tfplan > tfplan.json"
-          CHANGES="$(jq ".resource_changes | length" "${{ matrix.config }}/tfplan.json")"
+          CHANGES="$(jq "[.resource_changes[] | select(.change.actions != ["no-op"])] | length" "${{ matrix.config }}/tfplan.json")"
           if [ "$CHANGES" == "0" ]; then
             echo "No planned changes detected after first apply. Success!"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --input=false --out=tfplan"
           make terraform CONFIGURATION="${{ matrix.config }}" ARGS="show --json tfplan > tfplan.json"
-          CHANGES="$(jq "[.resource_changes[] | select(.change.actions != [\"no-op\"])] | length" "${{ matrix.config }}/tfplan.json")"
+          CHANGES="$(jq "[.resource_changes[]? | select(.change.actions != [\"no-op\"])] | length" "${{ matrix.config }}/tfplan.json")"
           if [ "$CHANGES" == "0" ]; then
             echo "No planned changes detected after first apply. Success!"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
   e2e_test:
     strategy:
       matrix:
-        terraform-version: [0.13, 0.14, 0.15, 1.0, 1.2, 1.4, 1.6, 1.8]
+        terraform-version: [0.14, 1.0, 1.8, latest]
         config: [examples/basic, examples/advanced, examples/on_call_calendars]
       fail-fast: false
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,12 @@ jobs:
         env:
           BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
       - name: Plan resources via Terraform - must be empty
-        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --detailed-exitcode --input=false"
+        run: |
+          make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --detailed-exitcode --input=false"
+          if [ $? -eq 2 ]; then
+            echo "Terraform plan has changes, exiting with error."
+            exit 1
+          fi
         env:
           BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
       - name: Destroy resources via Terraform

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,16 @@
-on: [push, pull_request]
 name: Test
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     strategy:
       matrix:
         go-version: [1.16.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
@@ -16,3 +21,39 @@ jobs:
       uses: actions/checkout@v2
     - name: Test
       run: go test ./...
+
+  e2e_test:
+    concurrency:
+      group: e2e
+    strategy:
+      matrix:
+        go-version: [1.16.x]
+        terraform-version: [0.13, 1.8.5]
+        config: [examples/basic, examples/advanced, examples/on_call_calendars]
+        os: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ matrix.terraform-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Add resources via Terraform
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="apply --auto-approve"
+        env:
+          BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
+      - name: Plan resources via Terraform - must be empty
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --detailed-exitcode"
+        env:
+          BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
+      - name: Destroy resources via Terraform
+        if: always()
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="destroy --auto-approve"
+        env:
+          BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,21 +23,17 @@ jobs:
       run: go test ./...
 
   e2e_test:
-    concurrency:
-      group: e2e
     strategy:
       matrix:
-        go-version: [1.16.x]
         terraform-version: [0.13, 1.8.5]
         config: [examples/basic, examples/advanced, examples/on_call_calendars]
-        os: [ubuntu-latest]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.16.x
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Add resources via Terraform
-        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="apply --auto-approve"
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="apply --auto-approve --input=false"
         env:
           BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
       - name: Plan resources via Terraform - must be empty
-        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --detailed-exitcode"
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="plan --detailed-exitcode --input=false"
         env:
           BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}
       - name: Destroy resources via Terraform
         if: always()
-        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="destroy --auto-approve"
+        run: make terraform CONFIGURATION="${{ matrix.config }}" ARGS="destroy --auto-approve --input=false"
         env:
           BETTERUPTIME_API_TOKEN: ${{ secrets.UPTIME_E2E_TEAM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # terraform-provider-better-uptime [![build](https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/workflows/build.yml) [![documentation](https://img.shields.io/badge/-documentation-blue)](https://registry.terraform.io/providers/BetterStackHQ/better-uptime/latest/docs)
 
-Terraform (0.13+) provider for [Better Uptime](https://uptime.betterstack.com/).
+Terraform (0.14+) provider for [Better Uptime](https://uptime.betterstack.com/).
 
 ## Installation
 
 ```terraform
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ The Better Uptime provider provides resources to interact with the [Better Uptim
 
 ```terraform
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -2,12 +2,17 @@ provider "betteruptime" {
   api_token = var.betteruptime_api_token
 }
 
+resource "random_id" "status_page_subdomain" {
+  byte_length = 8
+  prefix      = "tf-status-"
+}
+
 resource "betteruptime_status_page" "this" {
   company_name = "Example, Inc"
   company_url  = "https://example.com"
   contact_url  = "mailto:support@example.com"
   timezone     = "Eastern Time (US & Canada)"
-  subdomain    = var.betteruptime_status_page_subdomain
+  subdomain    = coalesce(var.betteruptime_status_page_subdomain, random_id.status_page_subdomain.hex)
   subscribable = true
 }
 

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -15,6 +15,8 @@ betteruptime.com status page subdomain
 (e.g. if you set value to "my-status-page" your status page will be
 available at https://my-status-page.betteruptime.com)
 EOF
+  # The value can be omitted and random domain will be provided.
+  default = null
 }
 
 variable "betteruptime_severity_name" {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -2,11 +2,16 @@ provider "betteruptime" {
   api_token = var.betteruptime_api_token
 }
 
+resource "random_id" "status_page_subdomain" {
+  byte_length = 8
+  prefix      = "tf-status-"
+}
+
 resource "betteruptime_status_page" "this" {
   company_name = "Example, Inc"
   company_url  = "https://example.com"
   timezone     = "UTC"
-  subdomain    = var.betteruptime_status_page_subdomain
+  subdomain    = coalesce(var.betteruptime_status_page_subdomain, random_id.status_page_subdomain.hex)
 }
 
 resource "betteruptime_monitor" "this" {

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -15,4 +15,6 @@ betteruptime.com status page subdomain
 (e.g. if you set value to "my-status-page" your status page will be
 available at https://my-status-page.betteruptime.com)
 EOF
+  # The value can be omitted and random domain will be provided.
+  default = null
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"

--- a/examples/on_call_calendars/versions.tf
+++ b/examples/on_call_calendars/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"

--- a/internal/provider/resource_status_page_section.go
+++ b/internal/provider/resource_status_page_section.go
@@ -36,9 +36,6 @@ var statusPageSectionSchema = map[string]*schema.Schema{
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Computed:    true,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return !d.HasChange(k)
-		},
 	},
 }
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,7 +13,7 @@ The Better Uptime provider provides resources to interact with the [Better Uptim
 
 ```terraform
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"


### PR DESCRIPTION
Adds end-to-end tests for our examples.

All examples need to be able to run with reasonable variable defaults (only team token should be required). Here I'd used `random_id` resource as a default for status page URL, and the advanced example requires severity with the name "Low Severity" (created by default by Better Stack, provided in the team used).

The tests revealed that Terraform 0.13 is not supported, updated docs to reflect it (≥0.14). See https://github.com/BetterStackHQ/terraform-provider-better-uptime/actions/runs/9766887794 for details.

E2E tests are set up to run daily, on demand, and in every PR.