### PR TITLE
Add plan-phase validation for request_headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.11.3
+VERSION := 0.11.7
 .PHONY: test build
 
 help:

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -37,6 +37,12 @@ resource "betteruptime_monitor" "status" {
   url              = "https://example.com"
   monitor_type     = "status"
   monitor_group_id = betteruptime_monitor_group.this.id
+  request_headers = [
+    {
+      "name" : "X-For-Status-Page",
+      "value" : "https://${betteruptime_status_page.this.subdomain}.betteruptime.com"
+    },
+  ]
 }
 
 resource "betteruptime_monitor" "dns" {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.8.0"
+      version = ">= 0.11.6"
     }
   }
 }

--- a/internal/provider/resource_aws_cloudwatch_integration.go
+++ b/internal/provider/resource_aws_cloudwatch_integration.go
@@ -152,7 +152,9 @@ func awsCloudWatchIntegrationCreate(ctx context.Context, d *schema.ResourceData,
 	var in awsCloudWatchIntegration
 	for _, e := range awsCloudWatchIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -193,7 +195,9 @@ func awsCloudWatchIntegrationUpdate(ctx context.Context, d *schema.ResourceData,
 	for _, e := range awsCloudWatchIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_aws_cloudwatch_integration.go
+++ b/internal/provider/resource_aws_cloudwatch_integration.go
@@ -97,8 +97,9 @@ func newAwsCloudWatchIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/aws-cloudwatch-integrations/",
-		Schema:      awsCloudWatchIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/aws-cloudwatch-integrations/",
+		Schema:        awsCloudWatchIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_azure_integration.go
+++ b/internal/provider/resource_azure_integration.go
@@ -152,7 +152,9 @@ func azureIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta in
 	var in azureIntegration
 	for _, e := range azureIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -193,7 +195,9 @@ func azureIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	for _, e := range azureIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_azure_integration.go
+++ b/internal/provider/resource_azure_integration.go
@@ -97,8 +97,9 @@ func newAzureIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/azure-integrations/",
-		Schema:      azureIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/azure-integrations/",
+		Schema:        azureIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_datadog_integration.go
+++ b/internal/provider/resource_datadog_integration.go
@@ -103,8 +103,9 @@ func newDatadogIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/datadog-integrations/",
-		Schema:      datadogIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/datadog-integrations/",
+		Schema:        datadogIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_datadog_integration.go
+++ b/internal/provider/resource_datadog_integration.go
@@ -160,7 +160,9 @@ func datadogIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta 
 	var in datadogIntegration
 	for _, e := range datadogIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -201,7 +203,9 @@ func datadogIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	for _, e := range datadogIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_google_monitoring_integration.go
+++ b/internal/provider/resource_google_monitoring_integration.go
@@ -97,8 +97,9 @@ func newGoogleMonitoringIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/google-monitoring-integrations/",
-		Schema:      googleMonitoringIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/google-monitoring-integrations/",
+		Schema:        googleMonitoringIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_google_monitoring_integration.go
+++ b/internal/provider/resource_google_monitoring_integration.go
@@ -152,7 +152,9 @@ func googleMonitoringIntegrationCreate(ctx context.Context, d *schema.ResourceDa
 	var in googleMonitoringIntegration
 	for _, e := range googleMonitoringIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -193,7 +195,9 @@ func googleMonitoringIntegrationUpdate(ctx context.Context, d *schema.ResourceDa
 	for _, e := range googleMonitoringIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_grafana_integration.go
+++ b/internal/provider/resource_grafana_integration.go
@@ -97,8 +97,9 @@ func newGrafanaIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/grafana-integrations/",
-		Schema:      grafanaIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/grafana-integrations/",
+		Schema:        grafanaIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_grafana_integration.go
+++ b/internal/provider/resource_grafana_integration.go
@@ -152,7 +152,9 @@ func grafanaIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta 
 	var in grafanaIntegration
 	for _, e := range grafanaIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -193,7 +195,9 @@ func grafanaIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	for _, e := range grafanaIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -116,7 +116,9 @@ func metadataCreate(ctx context.Context, d *schema.ResourceData, meta interface{
 	var in metadata
 	for _, e := range metadataRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -157,7 +159,9 @@ func metadataUpdate(ctx context.Context, d *schema.ResourceData, meta interface{
 	for _, e := range metadataRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -69,8 +69,9 @@ func newMetadataResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/metadata/",
-		Schema:      metadataSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/metadata/",
+		Schema:        metadataSchema,
 	}
 }
 

--- a/internal/provider/resource_new_relic_integration.go
+++ b/internal/provider/resource_new_relic_integration.go
@@ -103,8 +103,9 @@ func newNewRelicIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/new-relic-integrations/",
-		Schema:      newRelicIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/new-relic-integrations/",
+		Schema:        newRelicIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_new_relic_integration.go
+++ b/internal/provider/resource_new_relic_integration.go
@@ -160,7 +160,9 @@ func newRelicIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 	var in newRelicIntegration
 	for _, e := range newRelicIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -201,7 +203,9 @@ func newRelicIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	for _, e := range newRelicIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_pagerduty_integration.go
+++ b/internal/provider/resource_pagerduty_integration.go
@@ -48,8 +48,9 @@ func newPagerdutyIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/pagerduty-integrations/",
-		Schema:      pagerdutyIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/pagerduty-integrations/",
+		Schema:        pagerdutyIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_pagerduty_integration.go
+++ b/internal/provider/resource_pagerduty_integration.go
@@ -87,7 +87,9 @@ func pagerdutyIntegrationCreate(ctx context.Context, d *schema.ResourceData, met
 	var in pagerdutyIntegration
 	for _, e := range pagerdutyIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -128,7 +130,9 @@ func pagerdutyIntegrationUpdate(ctx context.Context, d *schema.ResourceData, met
 	for _, e := range pagerdutyIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_prometheus_integration.go
+++ b/internal/provider/resource_prometheus_integration.go
@@ -97,8 +97,9 @@ func newPrometheusIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/prometheus-integrations/",
-		Schema:      prometheusIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/prometheus-integrations/",
+		Schema:        prometheusIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_prometheus_integration.go
+++ b/internal/provider/resource_prometheus_integration.go
@@ -152,7 +152,9 @@ func prometheusIntegrationCreate(ctx context.Context, d *schema.ResourceData, me
 	var in prometheusIntegration
 	for _, e := range prometheusIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -193,7 +195,9 @@ func prometheusIntegrationUpdate(ctx context.Context, d *schema.ResourceData, me
 	for _, e := range prometheusIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_splunk_on_call_integration.go
+++ b/internal/provider/resource_splunk_on_call_integration.go
@@ -87,7 +87,9 @@ func splunkOnCallIntegrationCreate(ctx context.Context, d *schema.ResourceData, 
 	var in splunkOnCallIntegration
 	for _, e := range splunkOnCallIntegrationRef(&in) {
 		if e.k == "request_headers" {
-			loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+			if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+				return diag.FromErr(err)
+			}
 		} else {
 			load(d, e.k, e.v)
 		}
@@ -128,7 +130,9 @@ func splunkOnCallIntegrationUpdate(ctx context.Context, d *schema.ResourceData, 
 	for _, e := range splunkOnCallIntegrationRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "request_headers" {
-				loadRequestHeaders(d, e.v.(**[]map[string]interface{}))
+				if err := loadRequestHeaders(d, e.v.(**[]map[string]interface{})); err != nil {
+					return diag.FromErr(err)
+				}
 			} else {
 				load(d, e.k, e.v)
 			}

--- a/internal/provider/resource_splunk_on_call_integration.go
+++ b/internal/provider/resource_splunk_on_call_integration.go
@@ -48,8 +48,9 @@ func newSplunkOnCallIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/splunk-on-call-integrations/",
-		Schema:      splunkOnCallIntegrationSchema,
+		CustomizeDiff: validateRequestHeaders,
+		Description:   "https://betterstack.com/docs/uptime/api/splunk-on-call-integrations/",
+		Schema:        splunkOnCallIntegrationSchema,
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/104

Added `request_headers` usage into our examples (which means it will be used in our end-to-end tests).

Added validation into `CustomizeDiff`, because I found no other way to validate non-primitive in plan phase. `ValidateFunc` [only works for primitives](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors), and `loadRequestHeaders` is executed in apply phase.

I found it weird that the definition of `validateRequestHeaders` is in `resource_monitor.go` but used in other resources, but it follows the same logic as `loadRequestHeaders`.