### PR TITLE
Status page: Always send position of resource/section as fixed, if known

### DIFF
--- a/internal/provider/resource_status_page_resource_test.go
+++ b/internal/provider/resource_status_page_resource_test.go
@@ -64,7 +64,7 @@ func TestResourceStatusPageResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_status_page_resource.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "public_name", name),
 					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "resource_id", "3"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/status-pages/0/resources/1", `{"resource_id":3,"resource_type":"Monitor","fixed_position":true}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/status-pages/0/resources/1", `{"resource_id":3,"resource_type":"Monitor","position":0,"fixed_position":true}`),
 				),
 				PreConfig: func() {
 					t.Log("step 2")


### PR DESCRIPTION
`betteruptime_status_page_resource` gets placed at the end of the section if any property is updated although there is a position property defined.

The same behaviour happens with `betteruptime_status_page_section` too, they get placed at the end of the status page despite having a position property that should place it higher up.

Steps to reproduce:

Apply this config, then change name of `betteruptime_status_page_section.a` to `"A'"`, apply config again.

```
variable "betteruptime_api_token" {
  type        = string
  description = <<EOF
Better Stack Uptime API Token
(https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/#obtaining-an-uptime-api-token)
EOF
  # The value can be omitted if BETTERUPTIME_API_TOKEN env var is set.
  default = null
}

provider "betteruptime" {
  api_token = var.betteruptime_api_token
}

resource "random_id" "status_page_subdomain" {
  byte_length = 8
  prefix      = "tf-status-"
}

resource "betteruptime_status_page" "this" {
  company_name = "Example, Inc"
  company_url  = "https://example.com"
  contact_url  = "mailto:support@example.com"
  timezone     = "Eastern Time (US & Canada)"
  subdomain    = random_id.status_page_subdomain.hex
  subscribable = true
}

resource "betteruptime_status_page_section" "a" {
  status_page_id = betteruptime_status_page.this.id
  name           = "A"
  position       = 0
}

resource "betteruptime_status_page_section" "b" {
  status_page_id = betteruptime_status_page.this.id
  name           = "B"
  position       = 1
}

resource "betteruptime_status_page_section" "c" {
  status_page_id = betteruptime_status_page.this.id
  name           = "C"
}

resource "betteruptime_status_page_section" "d" {
  status_page_id = betteruptime_status_page.this.id
  name           = "D"
}
```

The resource will be moved to the bottom of the status page.

It will fix itself on subsequent apply, moving back to the top.

---

Here, the proposed fix is that `position` will always be sent, not only on change.

There is a disadvantage that known position will be sent even when it's not explicitly set in the config. This means if you apply for the first, and C is below D (~50% of cases), you cannot fix the position in GUI, because subsequent terraform apply will "fix" the position to the original.