### PR TITLE
Add support for wait_until_time in policy steps

### DIFF
--- a/docs/data-sources/betteruptime_policy.md
+++ b/docs/data-sources/betteruptime_policy.md
@@ -44,6 +44,8 @@ Read-Only:
 - **type** (String)
 - **urgency_id** (Number)
 - **wait_before** (Number)
+- **wait_until_time** (String)
+- **wait_until_timezone** (String)
 
 <a id="nestedobjatt--steps--step_members"></a>
 ### Nested Schema for `steps.step_members`

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -38,7 +38,6 @@ https://betterstack.com/docs/uptime/api/list-all-escalation-policies/
 Required:
 
 - **type** (String) The type of the step. Can be either escalation, time_branching, or metadata_branching.
-- **wait_before** (Number) How long to wait before executing this step since previous step.
 
 Optional:
 
@@ -51,6 +50,9 @@ Optional:
 - **time_to** (String) A time at which the branching rule will step being executed. Use HH:MM format. Used when step type is time_branching.
 - **timezone** (String) What timezone to use when evaluating time based branching rules. Used when step type is time_branching. The accepted values can be found in the Rails TimeZone documentation. https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
 - **urgency_id** (Number) Which severity to use for this step. Used when step type is escalation.
+- **wait_before** (Number) How long to wait in seconds before executing this step since previous step. Omit if wait_until_time is set.
+- **wait_until_time** (String) Execute this step at the specified time. Use HH:MM format. Omit if wait_before is set.
+- **wait_until_timezone** (String) Timezone to use when interpreting wait_until_time. Omit if wait_before is set.
 
 <a id="nestedblock--steps--step_members"></a>
 ### Nested Schema for `steps.step_members`

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -241,10 +241,6 @@ resource "betteruptime_incoming_webhook" "this" {
   }
 }
 
-data "betteruptime_severity" "this" {
-  name = var.betteruptime_severity_name
-}
-
 resource "betteruptime_policy_group" "this" {
   name = "Policies from Terraform"
 }
@@ -258,7 +254,7 @@ resource "betteruptime_policy" "this" {
   steps {
     type        = "escalation"
     wait_before = 0
-    urgency_id  = data.betteruptime_severity.this.id
+    urgency_id  = betteruptime_severity.this.id
     step_members { type = "all_slack_integrations" }
     step_members { type = "all_webhook_integrations" }
     step_members { type = "current_on_call" }
@@ -282,7 +278,7 @@ resource "betteruptime_policy" "this" {
   steps {
     type        = "escalation"
     wait_before = 180
-    urgency_id  = data.betteruptime_severity.this.id
+    urgency_id  = betteruptime_severity.this.id
     step_members { type = "entire_team" }
   }
 }
@@ -292,7 +288,7 @@ resource "betteruptime_severity_group" "this" {
 }
 
 resource "betteruptime_severity" "this" {
-  name  = "Terraform"
+  name  = var.betteruptime_severity_name
   call  = false
   email = false
   push  = false

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -22,5 +22,5 @@ EOF
 variable "betteruptime_severity_name" {
   type        = string
   description = "Name of the severity from Better Uptime you want to use with Escalation policies created using Terraform"
-  default     = "Low Severity"
+  default     = "Terraform Severity"
 }

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -41,9 +41,20 @@ var policyStepSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"wait_before": {
-		Description: "How long to wait before executing this step since previous step.",
+		Description: "How long to wait in seconds before executing this step since previous step. Omit if wait_until_time is set.",
 		Type:        schema.TypeInt,
-		Required:    true,
+		Optional:    true,
+	},
+	"wait_until_time": {
+		Description:  "Execute this step at the specified time. Use HH:MM format. Omit if wait_before is set.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(2[0-3]|[01][0-9]):[0-5][0-9]$`), "use HH:MM format"),
+	},
+	"wait_until_timezone": {
+		Description: "Timezone to use when interpreting wait_until_time. Omit if wait_before is set.",
+		Type:        schema.TypeString,
+		Optional:    true,
 	},
 	"urgency_id": {
 		Description: "Which severity to use for this step. Used when step type is escalation.",
@@ -180,17 +191,19 @@ type policyStepMember struct {
 }
 
 type policyStep struct {
-	Type           *string             `mapstructure:"type,omitempty" json:"type,omitempty"`
-	WaitBefore     *int                `mapstructure:"wait_before,omitempty" json:"wait_before,omitempty"`
-	UrgencyId      *int                `mapstructure:"urgency_id,omitempty" json:"urgency_id,omitempty"`
-	Steps          *[]policyStepMember `mapstructure:"step_members" json:"step_members"`
-	Timezone       *string             `mapstructure:"timezone,omitempty" json:"timezone,omitempty"`
-	Days           *[]string           `mapstructure:"days,omitempty" json:"days,omitempty"`
-	TimeFrom       *string             `mapstructure:"time_from,omitempty" json:"time_from,omitempty"`
-	TimeTo         *string             `mapstructure:"time_to,omitempty" json:"time_to,omitempty"`
-	MetadataKey    *string             `mapstructure:"metadata_key,omitempty" json:"metadata_key,omitempty"`
-	MetadataValues *[]string           `mapstructure:"metadata_values,omitempty" json:"metadata_values,omitempty"`
-	PolicyId       *int                `mapstructure:"policy_id,omitempty" json:"policy_id,omitempty"`
+	Type              *string             `mapstructure:"type,omitempty" json:"type,omitempty"`
+	WaitBefore        *int                `mapstructure:"wait_before,omitempty" json:"wait_before,omitempty"`
+	WaitUntilTime     *string             `mapstructure:"wait_until_time,omitempty" json:"wait_until_time,omitempty"`
+	WaitUntilTimezone *string             `mapstructure:"wait_until_timezone,omitempty" json:"wait_until_timezone,omitempty"`
+	UrgencyId         *int                `mapstructure:"urgency_id,omitempty" json:"urgency_id,omitempty"`
+	Steps             *[]policyStepMember `mapstructure:"step_members" json:"step_members"`
+	Timezone          *string             `mapstructure:"timezone,omitempty" json:"timezone,omitempty"`
+	Days              *[]string           `mapstructure:"days,omitempty" json:"days,omitempty"`
+	TimeFrom          *string             `mapstructure:"time_from,omitempty" json:"time_from,omitempty"`
+	TimeTo            *string             `mapstructure:"time_to,omitempty" json:"time_to,omitempty"`
+	MetadataKey       *string             `mapstructure:"metadata_key,omitempty" json:"metadata_key,omitempty"`
+	MetadataValues    *[]string           `mapstructure:"metadata_values,omitempty" json:"metadata_values,omitempty"`
+	PolicyId          *int                `mapstructure:"policy_id,omitempty" json:"policy_id,omitempty"`
 }
 
 type policy struct {


### PR DESCRIPTION
Adds support for two new fields:
- `wait_until_time`
- `wait_until_timezone`

Also marks `wait_before` as optional, since it is optional on the API side (defaults to `0`).
This is needed because `wait_before` and `wait_until_time` are mutually exclusive.

