### PR TITLE
Fix `pagerduty_integration` to include `severity` field

### DIFF
--- a/docs/resources/betteruptime_pagerduty_integration.md
+++ b/docs/resources/betteruptime_pagerduty_integration.md
@@ -18,6 +18,7 @@ https://betterstack.com/docs/uptime/api/pagerduty-integrations/
 ### Required
 
 - **key** (String) The PagerDuty routing key.
+- **severity** (String) The PagerDuty alert severity. Can be any of the following: info, warning, error, or critical.
 
 ### Optional
 

--- a/internal/provider/resource_pagerduty_integration.go
+++ b/internal/provider/resource_pagerduty_integration.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var pagerdutyIntegrationSchema = map[string]*schema.Schema{
@@ -37,6 +38,12 @@ var pagerdutyIntegrationSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Required:    true,
 	},
+	"severity": {
+		Description:  "The PagerDuty alert severity. Can be any of the following: info, warning, error, or critical.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"info", "warning", "error", "critical"}, false),
+	},
 }
 
 func newPagerdutyIntegrationResource() *schema.Resource {
@@ -59,6 +66,7 @@ type pagerdutyIntegration struct {
 	Name     *string `json:"name,omitempty"`
 	Key      *string `json:"key,omitempty"`
 	TeamName *string `json:"team_name,omitempty"`
+	Severity *string `json:"severity,omitempty"`
 }
 
 type pagerdutyIntegrationHTTPResponse struct {
@@ -80,6 +88,7 @@ func pagerdutyIntegrationRef(in *pagerdutyIntegration) []struct {
 		{k: "id", v: &in.ID},
 		{k: "name", v: &in.Name},
 		{k: "key", v: &in.Key},
+		{k: "severity", v: &in.Severity},
 	}
 }
 

--- a/internal/provider/resource_pagerduty_integration_test.go
+++ b/internal/provider/resource_pagerduty_integration_test.go
@@ -15,6 +15,7 @@ func TestResourcePagerDutyIntegration(t *testing.T) {
 
 	var name = "test"
 	var key = "keykeykeykey"
+	var pdSeverity = "critical"
 
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -34,12 +35,14 @@ func TestResourcePagerDutyIntegration(t *testing.T) {
 				resource "betteruptime_pagerduty_integration" "this" {
 					name = "%s"
 					key  = "%s"
+					severity  = "%s"
 				}
-				`, name, key),
+				`, name, key, pdSeverity),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_pagerduty_integration.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_pagerduty_integration.this", "name", name),
 					resource.TestCheckResourceAttr("betteruptime_pagerduty_integration.this", "key", key),
+					resource.TestCheckResourceAttr("betteruptime_pagerduty_integration.this", "severity", pdSeverity),
 				),
 			},
 			// Step 2 - update.
@@ -52,12 +55,14 @@ func TestResourcePagerDutyIntegration(t *testing.T) {
 				resource "betteruptime_pagerduty_integration" "this" {
 					name = "%s1"
 					key  = "%s"
+					severity  = "%s"
 				}
-				`, name, key),
+				`, name, key, pdSeverity),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_pagerduty_integration.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_pagerduty_integration.this", "name", fmt.Sprintf("%s1", name)),
 					resource.TestCheckResourceAttr("betteruptime_pagerduty_integration.this", "key", key),
+					resource.TestCheckResourceAttr("betteruptime_pagerduty_integration.this", "severity", pdSeverity),
 				),
 			},
 			// Step 3 - make no changes, check plan is empty.
@@ -70,8 +75,9 @@ func TestResourcePagerDutyIntegration(t *testing.T) {
 				resource "betteruptime_pagerduty_integration" "this" {
 					name = "%s1"
 					key  = "%s"
+					severity  = "%s"
 				}
-				`, name, key),
+				`, name, key, pdSeverity),
 				PlanOnly: true,
 			},
 			// Step 4 - destroy.


### PR DESCRIPTION
Updates pagerduty integration to require the `severity` field

`severity` can have one of the following values:
- info
- warning
- error
- critical


Currently, when attempting to create a new PagerDuty integration, the process fails with the following error:
```
╷
│ Error: POST https://uptime.betterstack.com/api/v2/pager-duty-webhooks returned 422: {"errors":{"severity":["can't be blank"]}}
│ 
│   with betteruptime_pagerduty_integration.pagerduty_integration["XXXX"],
│   on pagerduty_integrations.tf line 12, in resource "betteruptime_pagerduty_integration" "pagerduty_integration":
│   12: resource "betteruptime_pagerduty_integration" "pagerduty_integration" {
│ 
╵
```