### PR TITLE
U-4230 Make request_timeout for monitors docs more consistent and easier to parse

### DIFF
--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -88,11 +88,9 @@ Monitor lookup.
 - **request_body** (String) Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).
 - **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request?
-
-  - For Server and Port monitors (`ping`, `tcp`, `udp`, `smtp`, `pop`, `imap` and `dns`) timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.
-  - For all other monitor types timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
-
-  When monitor_type is set to playwright, this determines the Playwright scenario timeout instead. In *seconds*. Valid options: 15, 30, 45, 60
+  - For Server and Port monitors (types `ping`, `tcp`, `udp`, `smtp`, `pop`, `imap` and `dns`) the timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.
+  - For Playwright monitors (type `playwright`), this determines the Playwright scenario timeout instead in *seconds*. Valid options: 15, 30, 45, 60.
+  - For all other monitors, the timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - **scenario_name** (String) For Playwright monitors, the scenario name identifying the monitor in the UI.
 - **sms** (Boolean) Should we send an SMS to the on-call person?

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -84,7 +84,7 @@ https://betterstack.com/docs/uptime/api/monitors/
 - **request_body** (String) Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).
 - **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request?
-  - For Server and Port monitors (types `ping`, `tcp`, `udp`, `smtp`, `pop`, `imap`, and `dns`) the timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.
+  - For Server and Port monitors (types `ping`, `tcp`, `udp`, `smtp`, `pop`, `imap` and `dns`) the timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.
   - For Playwright monitors (type `playwright`), this determines the Playwright scenario timeout instead in *seconds*. Valid options: 15, 30, 45, 60.
   - For all other monitors, the timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -84,11 +84,9 @@ https://betterstack.com/docs/uptime/api/monitors/
 - **request_body** (String) Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).
 - **request_headers** (List of Map of String) An array of request headers, consisting of name and value pairs
 - **request_timeout** (Number) How long to wait before timing out the request?
-
-  - For Server and Port monitors (`ping`, `tcp`, `udp`, `smtp`, `pop`, `imap` and `dns`) timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.
-  - For all other monitor types timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
-
-  When monitor_type is set to playwright, this determines the Playwright scenario timeout instead. In *seconds*. Valid options: 15, 30, 45, 60
+  - For Server and Port monitors (types `ping`, `tcp`, `udp`, `smtp`, `pop`, `imap`, and `dns`) the timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.
+  - For Playwright monitors (type `playwright`), this determines the Playwright scenario timeout instead in *seconds*. Valid options: 15, 30, 45, 60.
+  - For all other monitors, the timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
 - **required_keyword** (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - **scenario_name** (String) For Playwright monitors, the scenario name identifying the monitor in the UI.
 - **sms** (Boolean) Should we send an SMS to the on-call person?

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -239,10 +239,10 @@ var monitorSchema = map[string]*schema.Schema{
 		// TODO: ValidateDiagFunc: validation.StringInSlice
 	},
 	"request_timeout": {
-		Description: "How long to wait before timing out the request?\n\n" +
-			"  - For Server and Port monitors (`ping`, `tcp`, `udp`, `smtp`, `pop`, `imap` and `dns`) timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.\n" +
-			"  - For all other monitor types timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.\n\n" +
-			"  When monitor_type is set to playwright, this determines the Playwright scenario timeout instead. In *seconds*. Valid options: 15, 30, 45, 60",
+		Description: "How long to wait before timing out the request?\n" +
+			"  - For Server and Port monitors (types `ping`, `tcp`, `udp`, `smtp`, `pop`, `imap` and `dns`) the timeout is specified in *milliseconds*. Valid options: 500, 1000, 2000, 3000, 5000.\n" +
+			"  - For Playwright monitors (type `playwright`), this determines the Playwright scenario timeout instead in *seconds*. Valid options: 15, 30, 45, 60.\n" +
+			"  - For all other monitors, the timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.\n",
 		Type:     schema.TypeInt,
 		Optional: true,
 		Computed: true,


### PR DESCRIPTION
The original format (#131) was running into issues when our internal checks tried to parse it, not understanding the arguments below it correctly.

This was it should be easy to parse, and maybe a bit easier to read as well.

Before:

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/d0d10de1-dc86-4e9a-9226-e3440b94ad90" />

After:

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/4f6744b7-8db2-41ac-b31e-77fcd81eaebd" />
