### PR TITLE
U-4488 Support new Policies v3 API in Terraform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.15.0
+VERSION := 0.16.0
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_policy.md
+++ b/docs/data-sources/betteruptime_policy.md
@@ -35,8 +35,9 @@ Read-Only:
 
 - **days** (List of String)
 - **metadata_key** (String)
-- **metadata_values** (List of String)
+- **metadata_value** (List of Object) (see [below for nested schema](#nestedobjatt--steps--metadata_value))
 - **policy_id** (Number)
+- **policy_metadata_key** (String)
 - **step_members** (List of Object) (see [below for nested schema](#nestedobjatt--steps--step_members))
 - **time_from** (String)
 - **time_to** (String)
@@ -46,6 +47,18 @@ Read-Only:
 - **wait_before** (Number)
 - **wait_until_time** (String)
 - **wait_until_timezone** (String)
+
+<a id="nestedobjatt--steps--metadata_value"></a>
+### Nested Schema for `steps.metadata_value`
+
+Read-Only:
+
+- **email** (String)
+- **item_id** (String)
+- **name** (String)
+- **type** (String)
+- **value** (String)
+
 
 <a id="nestedobjatt--steps--step_members"></a>
 ### Nested Schema for `steps.step_members`

--- a/docs/data-sources/betteruptime_policy.md
+++ b/docs/data-sources/betteruptime_policy.md
@@ -36,6 +36,7 @@ Read-Only:
 - **days** (List of String)
 - **metadata_key** (String)
 - **metadata_value** (List of Object) (see [below for nested schema](#nestedobjatt--steps--metadata_value))
+- **metadata_values** (List of String)
 - **policy_id** (Number)
 - **policy_metadata_key** (String)
 - **step_members** (List of Object) (see [below for nested schema](#nestedobjatt--steps--step_members))

--- a/docs/resources/betteruptime_catalog_record.md
+++ b/docs/resources/betteruptime_catalog_record.md
@@ -30,13 +30,13 @@ https://betterstack.com/docs/uptime/api/catalog-integrations-records/
 Required:
 
 - **attribute_id** (String) ID of the target Catalog attribute.
-- **type** (String) Type of the value.
 
 Optional:
 
 - **email** (String) Email of the referenced user when type is User.
 - **item_id** (String) ID of the referenced item when type is different than String.
 - **name** (String) Human readable name of the referenced item when type is different than String and the item has a name.
+- **type** (String) Type of the value. When left empty, the String type is used.
 - **value** (String) Value when type is String.
 
 Read-Only:

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -44,6 +44,7 @@ Optional:
 - **days** (List of String) An array of days during which the branching rule will be executed. Valid values are ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]. Used when step type is branching.
 - **metadata_key** (String) A metadata field key to check. Used when step type is metadata_branching.
 - **metadata_value** (Block List) An array of typed metadata values which will cause the branching rule to be executed. Used when step type is metadata_branching. (see [below for nested schema](#nestedblock--steps--metadata_value))
+- **metadata_values** (List of String, Deprecated) An array of metadata String values which will cause the branching rule to be executed. Used when step type is metadata_branching.
 - **policy_id** (Number) A policy to executed if the branching rule matches the time of an incident. Used when step type is time_branching or metadata_branching.
 - **policy_metadata_key** (String) A metadata key from which to extract the policy to executed if the branching rule matches the time of an incident. Used when step type is time_branching or metadata_branching.
 - **step_members** (Block List) An array of escalation policy steps members. Used when step type is escalation. (see [below for nested schema](#nestedblock--steps--step_members))

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -3,12 +3,12 @@
 page_title: "betteruptime_policy Resource - terraform-provider-better-uptime"
 subcategory: ""
 description: |-
-  https://betterstack.com/docs/uptime/api/list-all-escalation-policies/
+  https://betterstack.com/docs/uptime/api/policies/
 ---
 
 # betteruptime_policy (Resource)
 
-https://betterstack.com/docs/uptime/api/list-all-escalation-policies/
+https://betterstack.com/docs/uptime/api/policies/
 
 
 
@@ -43,8 +43,9 @@ Optional:
 
 - **days** (List of String) An array of days during which the branching rule will be executed. Valid values are ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]. Used when step type is branching.
 - **metadata_key** (String) A metadata field key to check. Used when step type is metadata_branching.
-- **metadata_values** (List of String) An array of metadata values which will cause the branching rule to be executed. Used when step type is metadata_branching.
+- **metadata_value** (Block List) An array of typed metadata values which will cause the branching rule to be executed. Used when step type is metadata_branching. (see [below for nested schema](#nestedblock--steps--metadata_value))
 - **policy_id** (Number) A policy to executed if the branching rule matches the time of an incident. Used when step type is time_branching or metadata_branching.
+- **policy_metadata_key** (String) A metadata key from which to extract the policy to executed if the branching rule matches the time of an incident. Used when step type is time_branching or metadata_branching.
 - **step_members** (Block List) An array of escalation policy steps members. Used when step type is escalation. (see [below for nested schema](#nestedblock--steps--step_members))
 - **time_from** (String) A time from which the branching rule will be executed. Use HH:MM format. Used when step type is time_branching.
 - **time_to** (String) A time at which the branching rule will step being executed. Use HH:MM format. Used when step type is time_branching.
@@ -53,6 +54,18 @@ Optional:
 - **wait_before** (Number) How long to wait in seconds before executing this step since previous step. Omit if wait_until_time is set.
 - **wait_until_time** (String) Execute this step at the specified time. Use HH:MM format. Omit if wait_before is set.
 - **wait_until_timezone** (String) Timezone to use when interpreting wait_until_time. Omit if wait_before is set.
+
+<a id="nestedblock--steps--metadata_value"></a>
+### Nested Schema for `steps.metadata_value`
+
+Optional:
+
+- **email** (String) Email of the referenced user when type is User.
+- **item_id** (String) ID of the referenced item when type is different than String.
+- **name** (String) Human readable name of the referenced item when type is different than String and the item has a name.
+- **type** (String) Type of the value. When left empty, the String type is used.
+- **value** (String) Value when type is String.
+
 
 <a id="nestedblock--steps--step_members"></a>
 ### Nested Schema for `steps.step_members`

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -284,11 +284,29 @@ resource "betteruptime_policy" "this" {
     policy_id   = null
   }
   steps {
-    type            = "metadata_branching"
-    wait_before     = 0
-    metadata_key    = "Description"
-    metadata_values = ["Low priority issue", "FYI", "Notice"]
-    policy_id       = null
+    type         = "metadata_branching"
+    wait_before  = 0
+    metadata_key = "Description"
+    metadata_value {
+      value = "Low priority issue"
+    }
+    metadata_value {
+      value = "FYI"
+    }
+    metadata_value {
+      value = "Notice"
+    }
+    policy_id = null
+  }
+  steps {
+    type         = "metadata_branching"
+    wait_before  = 0
+    metadata_key = "Assigned User"
+    metadata_value {
+      type  = "User"
+      email = "petr@betterstack.com"
+    }
+    policy_metadata_key = "Assigned Policy"
   }
   steps {
     type        = "escalation"

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.13.0"
+      version = ">= 0.16.0"
     }
   }
 }

--- a/internal/provider/data_policy.go
+++ b/internal/provider/data_policy.go
@@ -52,7 +52,7 @@ type policiesPageHTTPResponse struct {
 
 func policyLookup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	fetch := func(page int) (*policiesPageHTTPResponse, error) {
-		res, err := meta.(*client).Get(ctx, fmt.Sprintf("/api/v2/policies?page=%d", page))
+		res, err := meta.(*client).Get(ctx, fmt.Sprintf("/api/v3/policies?page=%d", page))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/provider/data_policy_test.go
+++ b/internal/provider/data_policy_test.go
@@ -19,7 +19,7 @@ func TestDataPolicy(t *testing.T) {
 			t.Fail()
 		}
 
-		prefix := "/api/v2/policies"
+		prefix := "/api/v3/policies"
 
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=1":

--- a/internal/provider/resource_catalog_record_test.go
+++ b/internal/provider/resource_catalog_record_test.go
@@ -94,7 +94,7 @@ func TestResourceCatalogRecordValidation(t *testing.T) {
 					}
 				}
 			`,
-			expectError: regexp.MustCompile("value must be set for String type attribute"),
+			expectError: regexp.MustCompile("value must be set for String type"),
 		},
 		{
 			name: "invalid string attribute - with item_id",
@@ -113,7 +113,7 @@ func TestResourceCatalogRecordValidation(t *testing.T) {
 					}
 				}
 			`,
-			expectError: regexp.MustCompile("item_id must not be set for String type attribute"),
+			expectError: regexp.MustCompile("item_id must not be set for String type"),
 		},
 		{
 			name: "valid user attribute",
@@ -150,7 +150,7 @@ func TestResourceCatalogRecordValidation(t *testing.T) {
 					}
 				}
 			`,
-			expectError: regexp.MustCompile("value must not be set for User type attribute"),
+			expectError: regexp.MustCompile("value must not be set for User type"),
 		},
 		{
 			name: "invalid user attribute - no identifier",
@@ -167,7 +167,7 @@ func TestResourceCatalogRecordValidation(t *testing.T) {
 					}
 				}
 			`,
-			expectError: regexp.MustCompile("at least one of item_id, email, or name must be set for User type attribute"),
+			expectError: regexp.MustCompile("at least one of item_id, email, or name must be set for User type"),
 		},
 	}
 

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -104,11 +104,11 @@ var metadataValueSchema = map[string]*schema.Schema{
 }
 
 type metadataValue struct {
-	Type   string      `json:"type"`
-	Value  *string     `json:"value,omitempty"`
-	ItemID json.Number `json:"item_id,omitempty"`
-	Name   *string     `json:"name,omitempty"`
-	Email  *string     `json:"email,omitempty"`
+	Type   string      `mapstructure:"type" json:"type"`
+	Value  *string     `mapstructure:"value,omitempty" json:"value,omitempty"`
+	ItemID json.Number `mapstructure:"item_id,omitempty" json:"item_id,omitempty"`
+	Name   *string     `mapstructure:"name,omitempty" json:"name,omitempty"`
+	Email  *string     `mapstructure:"email,omitempty" json:"email,omitempty"`
 }
 
 func newMetadataResource() *schema.Resource {

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -72,7 +72,7 @@ var metadataTypes = []string{
 
 var metadataValueSchema = map[string]*schema.Schema{
 	"type": {
-		Description:  "Type of the value.",
+		Description:  "Type of the value. When left empty, the String type is used.",
 		Type:         schema.TypeString,
 		Optional:     true,
 		Default:      "String",

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -384,6 +384,12 @@ func validatePolicy(ctx context.Context, d *schema.ResourceDiff, m interface{}) 
 		stepMap := step.(map[string]interface{})
 
 		if stepMap["type"].(string) == "metadata_branching" {
+			if stepMap["metadata_key"].(string) == "" {
+				return fmt.Errorf("steps.%d: missing metadata_key for metadata_branching step", i)
+			}
+			if len(stepMap["metadata_value"].([]interface{})) == 0 {
+				return fmt.Errorf("steps.%d: there must be at least 1 metadata_value for metadata_branching step", i)
+			}
 			if err := validatePolicyMetadataValues(stepMap, fmt.Sprintf("steps.%d", i)); err != nil {
 				return err
 			}

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -68,8 +68,9 @@ func TestResourcePolicy(t *testing.T) {
 					t.Log("step 1")
 				},
 			},
-			// Step 2 - change to a branching policy.
+			// Step 2 - change to a branching policy, use legacy metadata_values
 			{
+				ExpectNonEmptyPlan: true, // Ignoring plan not empty error since we're using legacy metadata_values attribute
 				Config: `
                 provider "betteruptime" {
 					api_token = "foo"
@@ -99,12 +100,7 @@ func TestResourcePolicy(t *testing.T) {
                     type            = "metadata_branching"
                     wait_before     = 0
                     metadata_key    = "severity"
-                    metadata_value {
-                      value = "critical"
-					}
-                    metadata_value {
-                      value = "error"
-					}
+                    metadata_values = ["critical", "error"]
                     policy_id = 456
                   }
 				}
@@ -137,7 +133,7 @@ func TestResourcePolicy(t *testing.T) {
 					t.Log("step 2")
 				},
 			},
-			// Step 3 - make no changes, check plan is empty.
+			// Step 3 - make no changes, only update to metadata_value blocks, check plan is empty.
 			{
 				Config: `
                 provider "betteruptime" {

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestResourcePolicy(t *testing.T) {
-	server := newResourceServer(t, "/api/v2/policies", "1")
+	server := newResourceServer(t, "/api/v3/policies", "1")
 	defer server.Close()
 
 	resource.Test(t, resource.TestCase{
@@ -93,14 +93,19 @@ func TestResourcePolicy(t *testing.T) {
                     days        = ["sat", "sun"]
                     time_from   = "08:00"
                     time_to     = "22:00"
-                    policy_id   = 456
+                    policy_metadata_key = "Team Policy"
                   }
                   steps {
                     type            = "metadata_branching"
                     wait_before     = 0
                     metadata_key    = "severity"
-                    metadata_values = ["critical", "error"]
-                    policy_id       = 456
+                    metadata_value {
+                      value = "critical"
+					}
+                    metadata_value {
+                      value = "error"
+					}
+                    policy_id = 456
                   }
 				}
 				`,
@@ -118,12 +123,14 @@ func TestResourcePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.timezone", "Prague"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.days.0", "sat"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.time_to", "22:00"),
-					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.policy_id", "456"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.policy_metadata_key", "Team Policy"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.type", "metadata_branching"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.wait_before", "0"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_key", "severity"),
-					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_values.0", "critical"),
-					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_values.1", "error"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_value.0.type", "String"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_value.0.value", "critical"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_value.1.type", "String"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.metadata_value.1.value", "error"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.2.policy_id", "456"),
 				),
 				PreConfig: func() {
@@ -155,14 +162,19 @@ func TestResourcePolicy(t *testing.T) {
                     days        = ["sat", "sun"]
                     time_from   = "08:00"
                     time_to     = "22:00"
-                    policy_id   = 456
+                    policy_metadata_key = "Team Policy"
                   }
                   steps {
                     type            = "metadata_branching"
                     wait_before     = 0
                     metadata_key    = "severity"
-                    metadata_values = ["critical", "error"]
-                    policy_id       = 456
+                    metadata_value {
+                      value = "critical"
+					}
+                    metadata_value {
+                      value = "error"
+					}
+                    policy_id = 456
                   }
 				}`,
 				PlanOnly: true,


### PR DESCRIPTION
Using `metadata_value` block list instead of `metadata_values` string array.

Before:
```tf
  steps {
    type = "metadata_branching"
    wait_before = 0
    metadata_key = "Severity"
    metadata_values = ["low", "med"]
    policy_id = nil
  }
```

After:
```tf
  steps {
    type = "metadata_branching"
    wait_before = 0
    metadata_key = "Severity"
    metadata_value { value = "low" }
    metadata_value { value = "med" }
    policy_id = nil
  }
```

Also allows using typed values and `policy_metadata_key`:
```tf
  steps {
    type = "metadata_branching"
    wait_before = 0
    metadata_key = "Assigned User"
    metadata_value { type = "User", email = "petr@betterstack.com" }
    policy_metadata_key = "Assigned Policy"
  }
```

---

Added some validation, and backward-compatibility. The BC comes with a caveat that after re-applying changes are always seen by the provider if you're using the legacy `metadata_values`.