### PR TITLE
U-4293 Catalog and Policies v3 tweaks

### DIFF
--- a/internal/provider/resource_catalog_record_test.go
+++ b/internal/provider/resource_catalog_record_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
 
@@ -189,4 +191,80 @@ func TestResourceCatalogRecordValidation(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestResourceCatalogRecordStateCleanup(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/catalog/relations/123/records", "2")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - Create with User type
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_catalog_record" "test" {
+					relation_id = "123"
+					attribute {
+						attribute_id = "789"
+						type        = "User"
+						email       = "test@example.com"
+					}
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					// Simulate API setting computed fields
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["betteruptime_catalog_record.test"]
+						if !ok {
+							return fmt.Errorf("resource not found")
+						}
+						rs.Primary.Attributes["attribute.0.item_id"] = "456"
+						rs.Primary.Attributes["attribute.0.name"] = "Test User"
+						return nil
+					},
+					// Verify all User type fields are present
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.type", "User"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.email", "test@example.com"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.item_id", "456"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.name", "Test User"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.value", ""),
+				),
+			},
+			// Step 2 - Update to String type, should clean up computed fields
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_catalog_record" "test" {
+					relation_id = "123"
+					attribute {
+						attribute_id = "789"
+						type        = "String"
+						value       = "test@example.com"
+					}
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					// Verify only String type fields are present
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.type", "String"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.value", "test@example.com"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.email", ""),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.item_id", ""),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.name", ""),
+				),
+			},
+		},
+	})
 }

--- a/internal/provider/resource_catalog_record_test.go
+++ b/internal/provider/resource_catalog_record_test.go
@@ -2,9 +2,10 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -87,19 +87,16 @@ var metadataValueSchema = map[string]*schema.Schema{
 		Description: "ID of the referenced item when type is different than String.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"name": {
 		Description: "Human readable name of the referenced item when type is different than String and the item has a name.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"email": {
 		Description: "Email of the referenced user when type is User.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 }
 

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -291,11 +291,37 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 
 func policyCopyAttrs(d *schema.ResourceData, in *policy) diag.Diagnostics {
 	var derr diag.Diagnostics
+
+	// Remember which item_id, name, and email from metadata values in policy steps were not configured
+	var emptyPaths []string
+	if in.Steps != nil {
+		for stepIndex, step := range *in.Steps {
+			if step.MetadataValues != nil {
+				for valueIndex := range *step.MetadataValues {
+					for _, field := range []string{"item_id", "name", "email"} {
+						path := fmt.Sprintf("steps.%d.metadata_value.%d.%s", stepIndex, valueIndex, field)
+						if value, ok := d.GetOk(path); !ok || value == "" {
+							emptyPaths = append(emptyPaths, path)
+						}
+					}
+				}
+			}
+		}
+	}
+
 	for _, e := range policyRef(in) {
 		if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}
 	}
+
+	// Remove item_id, name, and email from metadata values in policy steps if they were not configured, avoid loading them from API
+	for _, path := range emptyPaths {
+		if err := d.Set(path, nil); err != nil {
+			derr = append(derr, diag.FromErr(err)[0])
+		}
+	}
+
 	return derr
 }
 


### PR DESCRIPTION
The was an issue with the computed optional metadata value fields item_id, email, and name:

When you saved {type:"User",email:"foo@example.com"}, you would get item_id and name in the response, saving it into state.
This extra state would get saved.
When chasing that value to {type:"String",value:"my string"}, the previously saved item_id and name would be send alongside.

I tried to overcome this issue, but haven't found a way to distinguish the computed optional values from human-configured values.

My solution here is to remove the Computed flag from these fields, and prevent saving the values from API. If this wasn't prevented, the plan after applying would always include the attempt to remove the item_id and name from the value, making the plan unstable.

Fixes both https://github.com/BetterStackHQ/terraform-provider-better-uptime/pull/136 and https://github.com/BetterStackHQ/terraform-provider-better-uptime/pull/137