### PR TITLE
U-4519 Manage on-call calendar rotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.16.0
+VERSION := 0.17.0
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_on_call_calendar.md
+++ b/docs/data-sources/betteruptime_on_call_calendar.md
@@ -23,7 +23,20 @@ On-call calendar lookup.
 
 - **default_calendar** (Boolean) Whether the on-call calendar is the default on-call calendar.
 - **id** (String) The ID of the on-call calendar.
+- **on_call_rotation** (List of Object) Configuration block for the on-call rotation schedule. Ignored when omitted - on-call can be controlled in Better Stack. (see [below for nested schema](#nestedatt--on_call_rotation))
 - **on_call_users** (List of Object) Array of on-call persons. (see [below for nested schema](#nestedatt--on_call_users))
+
+<a id="nestedatt--on_call_rotation"></a>
+### Nested Schema for `on_call_rotation`
+
+Read-Only:
+
+- **end_rotations_at** (String)
+- **rotation_interval** (String)
+- **rotation_length** (Number)
+- **start_rotations_at** (String)
+- **users** (List of String)
+
 
 <a id="nestedatt--on_call_users"></a>
 ### Nested Schema for `on_call_users`

--- a/docs/resources/betteruptime_on_call_calendar.md
+++ b/docs/resources/betteruptime_on_call_calendar.md
@@ -21,6 +21,7 @@ https://betterstack.com/docs/uptime/api/on-call-calendar/
 
 ### Optional
 
+- **on_call_rotation** (Block List, Max: 1) Configuration block for the on-call rotation schedule. Ignored when omitted - on-call can be controlled in Better Stack. (see [below for nested schema](#nestedblock--on_call_rotation))
 - **team_name** (String) Used to specify the team the resource should be created in when using global tokens.
 
 ### Read-Only
@@ -28,6 +29,18 @@ https://betterstack.com/docs/uptime/api/on-call-calendar/
 - **default_calendar** (Boolean) Whether the on-call calendar is the default on-call calendar.
 - **id** (String) The ID of the on-call calendar.
 - **on_call_users** (List of Object) Array of on-call persons. (see [below for nested schema](#nestedatt--on_call_users))
+
+<a id="nestedblock--on_call_rotation"></a>
+### Nested Schema for `on_call_rotation`
+
+Required:
+
+- **end_rotations_at** (String) End time of the rotation in RFC 3339 format (e.g. `2026-01-01T00:00:00Z`)
+- **rotation_interval** (String) The interval unit for rotation_length. Must be one of: `hour`, `day`, `week`.
+- **rotation_length** (Number) The length of each rotation shift. See `rotation_interval` for units.
+- **start_rotations_at** (String) Start time of the rotation in RFC 3339 format (e.g. `2026-01-01T00:00:00Z`)
+- **users** (List of String) List of email addresses for users participating in the rotation.
+
 
 <a id="nestedatt--on_call_users"></a>
 ### Nested Schema for `on_call_users`

--- a/examples/on_call_calendars/README.md
+++ b/examples/on_call_calendars/README.md
@@ -10,6 +10,7 @@ git clone https://github.com/BetterStackHQ/terraform-provider-better-uptime && \
 echo '# See variables.tf for more.
 betteruptime_api_token               = "XXXXXXXXXXXXXXXXXXXXXXXX"
 betteruptime_secondary_calendar_name = "My secondary calendar"
+betteruptime_rotation_users = ["albert@acme.com", "betty@acme.com", "charlie@acme.com"]
 ' > terraform.tfvars
 
 terraform init

--- a/examples/on_call_calendars/main.tf
+++ b/examples/on_call_calendars/main.tf
@@ -11,7 +11,7 @@ data "betteruptime_on_call_calendar" "secondary" {
 resource "betteruptime_on_call_calendar" "new" {
   name = "My Terraform calendar"
   on_call_rotation {
-    user_emails = ["petr@betterstack.com", "simon@betterstack.com"]
+    users = ["petr@betterstack.com", "simon@betterstack.com"]
     rotation_length = 1
     rotation_interval = "day"
     start_rotations_at = "2025-01-01T00:00:00Z"

--- a/examples/on_call_calendars/main.tf
+++ b/examples/on_call_calendars/main.tf
@@ -10,4 +10,11 @@ data "betteruptime_on_call_calendar" "secondary" {
 
 resource "betteruptime_on_call_calendar" "new" {
   name = "My Terraform calendar"
+  on_call_rotation {
+    user_emails = ["petr@betterstack.com", "simon@betterstack.com"]
+    rotation_length = 1
+    rotation_interval = "day"
+    start_rotations_at = "2025-01-01T00:00:00.000Z"
+    end_rotations_at = "2026-01-01T00:00:00.000Z"
+  }
 }

--- a/examples/on_call_calendars/main.tf
+++ b/examples/on_call_calendars/main.tf
@@ -14,7 +14,7 @@ resource "betteruptime_on_call_calendar" "new" {
     user_emails = ["petr@betterstack.com", "simon@betterstack.com"]
     rotation_length = 1
     rotation_interval = "day"
-    start_rotations_at = "2025-01-01T00:00:00.000Z"
-    end_rotations_at = "2026-01-01T00:00:00.000Z"
+    start_rotations_at = "2025-01-01T00:00:00Z"
+    end_rotations_at = "2026-01-01T00:00:00Z"
   }
 }

--- a/examples/on_call_calendars/main.tf
+++ b/examples/on_call_calendars/main.tf
@@ -11,7 +11,7 @@ data "betteruptime_on_call_calendar" "secondary" {
 resource "betteruptime_on_call_calendar" "new" {
   name = "My Terraform calendar"
   on_call_rotation {
-    users              = ["petr@betterstack.com", "simon@betterstack.com"]
+    users              = var.betteruptime_rotation_users
     rotation_length    = 1
     rotation_interval  = "day"
     start_rotations_at = "2025-01-01T00:00:00Z"

--- a/examples/on_call_calendars/main.tf
+++ b/examples/on_call_calendars/main.tf
@@ -11,10 +11,10 @@ data "betteruptime_on_call_calendar" "secondary" {
 resource "betteruptime_on_call_calendar" "new" {
   name = "My Terraform calendar"
   on_call_rotation {
-    users = ["petr@betterstack.com", "simon@betterstack.com"]
-    rotation_length = 1
-    rotation_interval = "day"
+    users              = ["petr@betterstack.com", "simon@betterstack.com"]
+    rotation_length    = 1
+    rotation_interval  = "day"
     start_rotations_at = "2025-01-01T00:00:00Z"
-    end_rotations_at = "2026-01-01T00:00:00Z"
+    end_rotations_at   = "2026-01-01T00:00:00Z"
   }
 }

--- a/examples/on_call_calendars/variables.tf
+++ b/examples/on_call_calendars/variables.tf
@@ -15,3 +15,11 @@ The name of your secondary on-call calendar.
 EOF
   default     = "Secondary calendar"
 }
+
+variable "betteruptime_rotation_users" {
+  type        = list(string)
+  description = <<EOF
+Emails of users to use in new on-call rotation.
+EOF
+  default     = ["petr@betterstack.com", "simon@betterstack.com"]
+}

--- a/examples/on_call_calendars/versions.tf
+++ b/examples/on_call_calendars/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.9.0"
+      version = ">= 0.17.0"
     }
   }
 }

--- a/internal/provider/data_on_call_calendar_test.go
+++ b/internal/provider/data_on_call_calendar_test.go
@@ -26,6 +26,8 @@ func TestOnCallCalendarData(t *testing.T) {
 			_, _ = w.Write([]byte(`{"data":[{"id":"123","attributes":{"name":"Primary","default_calendar":true},"relationships":{"on_call_users":{"data":[{"id":"123456","type":"user"}]}}}],"included":[{"id":"123456","type":"user","attributes":{"first_name":"John","last_name":"Smith","email":"john@example.com","phone_numbers":[]}}],"pagination":{"next":"..."}}`))
 		case r.Method == http.MethodGet && r.RequestURI == prefix+"?page=2":
 			_, _ = w.Write([]byte(`{"data":[{"id":"456","attributes":{"name":"Secondary","default_calendar":false},"relationships":{"on_call_users":{"data":[{"id":"456789","type":"user"}]}}}],"included":[{"id":"456789","type":"user","attributes":{"first_name":"Jane","last_name":"Doe","email":"jane@example.com","phone_numbers":["+44 808 157 0192"]}}],"pagination":{"next":null}}`))
+		case r.Method == http.MethodGet && r.RequestURI == prefix+"/456/rotation":
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
 			t.Fail()
@@ -62,6 +64,7 @@ func TestOnCallCalendarData(t *testing.T) {
 					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_users.0.last_name", "Doe"),
 					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_users.0.email", "jane@example.com"),
 					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_users.0.phone_numbers.0", "+44 808 157 0192"),
+					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_rotation.#", "0"),
 				),
 			},
 		},
@@ -80,6 +83,8 @@ func TestDefaultOnCallCalendarData(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/on-calls/default":
 			_, _ = w.Write([]byte(`{"data":{"id":"123","attributes":{"name":"Primary","default_calendar":true},"relationships":{"on_call_users":{"data":[{"id":"123456","type":"user"}]}}},"included":[{"id":"123456","type":"user","attributes":{"first_name":"John","last_name":"Smith","email":"john@example.com","phone_numbers":[]}}]}`))
+		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/on-calls/123/rotation":
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
 			t.Fail()
@@ -112,6 +117,7 @@ func TestDefaultOnCallCalendarData(t *testing.T) {
 					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_users.0.first_name", "John"),
 					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_users.0.last_name", "Smith"),
 					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_users.0.email", "john@example.com"),
+					resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "on_call_rotation.#", "0"),
 				),
 			},
 		},

--- a/internal/provider/resource_on_call_calendar.go
+++ b/internal/provider/resource_on_call_calendar.go
@@ -85,7 +85,7 @@ var onCallCalendarSchema = map[string]*schema.Schema{
 		},
 	},
 	"on_call_rotation": {
-		Description: "TODO",
+		Description: "Configuration block for the on-call rotation schedule. Ignored when omitted - on-call can be controlled in Better Stack.",
 		Type:        schema.TypeList,
 		Optional:    true,
 		Computed:    true,
@@ -93,7 +93,7 @@ var onCallCalendarSchema = map[string]*schema.Schema{
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"users": {
-					Description: "TODO",
+					Description: "List of email addresses for users participating in the rotation.",
 					Type:        schema.TypeList,
 					Required:    true,
 					Elem: &schema.Schema{
@@ -101,25 +101,25 @@ var onCallCalendarSchema = map[string]*schema.Schema{
 					},
 				},
 				"rotation_length": {
-					Description: "TODO",
+					Description: "The length of each rotation shift. See `rotation_interval` for units.",
 					Type:        schema.TypeInt,
 					Required:    true,
 				},
 				"rotation_interval": {
-					Description:  "TODO",
+					Description:  "The interval unit for rotation_length. Must be one of: `hour`, `day`, `week`.",
 					Type:         schema.TypeString,
 					Required:     true,
 					ValidateFunc: validation.StringInSlice([]string{"hour", "day", "week"}, false),
 				},
 				"start_rotations_at": {
-					Description:      "Start time of the rotation in RFC 3339 format (e.g. 2026-01-01T00:00:00Z)",
+					Description:      "Start time of the rotation in RFC 3339 format (e.g. `2026-01-01T00:00:00Z`)",
 					Type:             schema.TypeString,
 					Required:         true,
 					ValidateDiagFunc: validateRFC3339DateTime,
 					DiffSuppressFunc: diffSuppressRFC3339DateTime,
 				},
 				"end_rotations_at": {
-					Description:      "End time of the rotation in RFC 3339 format (e.g. 2026-01-01T00:00:00Z)",
+					Description:      "End time of the rotation in RFC 3339 format (e.g. `2026-01-01T00:00:00Z`)",
 					Type:             schema.TypeString,
 					Required:         true,
 					ValidateDiagFunc: validateRFC3339DateTime,

--- a/internal/provider/resource_on_call_calendar.go
+++ b/internal/provider/resource_on_call_calendar.go
@@ -295,7 +295,14 @@ func resourceOnCallCalendarCreate(ctx context.Context, d *schema.ResourceData, m
 		return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, &outRotation)
 	}
 
-	return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, nil)
+	var outRotation onCallRotation
+	if err, ok := resourceRead(ctx, meta, fmt.Sprintf("/api/v2/on-calls/%s/rotation", url.PathEscape(d.Id())), &outRotation); err != nil {
+		return err
+	} else if !ok {
+		return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, nil)
+	}
+
+	return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, &outRotation)
 }
 
 func resourceOnCallCalendarRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -356,7 +363,14 @@ func resourceOnCallCalendarUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, nil)
+	var outRotation onCallRotation
+	if err, ok := resourceRead(ctx, meta, fmt.Sprintf("/api/v2/on-calls/%s/rotation", url.PathEscape(d.Id())), &outRotation); err != nil {
+		return err
+	} else if !ok {
+		return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, nil)
+	}
+
+	return onCallCalendarCopyAttrs(d, &out.Data.Attributes, out.Data.Relationships, out.Included, &outRotation)
 }
 
 func resourceOnCallCalendarDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_on_call_calendar_test.go
+++ b/internal/provider/resource_on_call_calendar_test.go
@@ -2,19 +2,36 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
+	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestAccResourceOnCallCalendar(t *testing.T) {
+func TestAccResourceOnCallCalendarWithRotation(t *testing.T) {
 	id := "123"
 	name := "Test Calendar"
 	updatedName := "Updated Calendar"
 
 	server := newResourceServer(t, "/api/v2/on-calls", id)
+
+	server.ExpectRequest(
+		"POST",
+		"/api/v2/on-calls/123/rotation",
+		`{"end_rotations_at":"2026-01-01T01:00:00+01:00","rotation_interval":"day","rotation_length":1,"start_rotations_at":"2025-01-01T01:00:00+01:00","users":["user1@example.com","user2@example.com"]}`,
+		http.StatusCreated,
+		`{"users":["user1@example.com","user2@example.com"],"rotation_length":1,"rotation_interval":"day","start_rotations_at":"2025-01-01T00:00:00Z","end_rotations_at":"2026-01-01T00:00:00Z"}`,
+	)
+	server.ExpectRequest(
+		"GET",
+		"/api/v2/on-calls/123/rotation",
+		"",
+		http.StatusOK,
+		`{"users":["user1@example.com","user2@example.com"],"rotation_length":1,"rotation_interval":"day","start_rotations_at":"2025-01-01T00:00:00Z","end_rotations_at":"2026-01-01T00:00:00Z"}`,
+	)
+
 	defer server.Close()
 
 	resource.UnitTest(t, resource.TestCase{
@@ -25,7 +42,7 @@ func TestAccResourceOnCallCalendar(t *testing.T) {
 			},
 		},
 		Steps: []resource.TestStep{
-			// Step 1 - create
+			// Step 1 - create with rotation
 			{
 				Config: fmt.Sprintf(`
 				provider "betteruptime" {
@@ -34,15 +51,72 @@ func TestAccResourceOnCallCalendar(t *testing.T) {
 
 				resource "betteruptime_on_call_calendar" "test" {
 					name = "%s"
+					on_call_rotation {
+						users = ["user1@example.com", "user2@example.com"]
+						rotation_length = 1
+						rotation_interval = "day"
+						start_rotations_at = "2025-01-01T01:00:00+01:00"
+						end_rotations_at = "2026-01-01T01:00:00+01:00"
+					}
 				}
 				`, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "id", id),
 					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "name", name),
 					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "default_calendar", "false"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.#", "1"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.users.#", "2"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.users.0", "user1@example.com"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.users.1", "user2@example.com"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.rotation_length", "1"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.rotation_interval", "day"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.start_rotations_at", "2025-01-01T00:00:00Z"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.end_rotations_at", "2026-01-01T00:00:00Z"),
 				),
 			},
-			// Step 2 - update
+			// Step 2 - test invalid rotation interval
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_on_call_calendar" "test" {
+					name = "%s"
+					on_call_rotation {
+						users = ["user1@example.com"]
+						rotation_length = 1
+						rotation_interval = "invalid"
+						start_rotations_at = "2025-01-01T00:00:00Z"
+						end_rotations_at = "2026-01-01T00:00:00Z"
+					}
+				}
+				`, name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected on_call_rotation.0.rotation_interval to be one of \[hour day week\], got invalid`),
+			},
+			// Step 3 - test invalid datetime format
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_on_call_calendar" "test" {
+					name = "%s"
+					on_call_rotation {
+						users = ["user1@example.com"]
+						rotation_length = 1
+						rotation_interval = "day"
+						start_rotations_at = "2025-01-01"
+						end_rotations_at = "2026-01-01T00:00:00Z"
+					}
+				}
+				`, name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected RFC 3339 datetime \(e\.g\. 2026-01-01T00:00:00Z\), got 2025-01-01`),
+			},
+			// Step 4 - update, remove rotation (kept managed in Better Stack)
 			{
 				Config: fmt.Sprintf(`
 				provider "betteruptime" {
@@ -54,12 +128,20 @@ func TestAccResourceOnCallCalendar(t *testing.T) {
 				}
 				`, updatedName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("betteruptime_on_call_calendar.test", "id"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "id", id),
 					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "name", updatedName),
 					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "default_calendar", "false"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.#", "1"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.users.#", "2"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.users.0", "user1@example.com"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.users.1", "user2@example.com"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.rotation_length", "1"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.rotation_interval", "day"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.start_rotations_at", "2025-01-01T00:00:00Z"),
+					resource.TestCheckResourceAttr("betteruptime_on_call_calendar.test", "on_call_rotation.0.end_rotations_at", "2026-01-01T00:00:00Z"),
 				),
 			},
-			// Step 3 - import
+			// Step 5 - import
 			{
 				ResourceName:      "betteruptime_on_call_calendar.test",
 				ImportState:       true,

--- a/internal/provider/resource_test.go
+++ b/internal/provider/resource_test.go
@@ -20,11 +20,20 @@ type CalledRequest struct {
 	Body   string
 }
 
+type ExpectedRequest struct {
+	Method     string
+	URL        string
+	Body       string
+	StatusCode int
+	Response   string
+}
+
 type TestServer struct {
 	*httptest.Server
-	CalledRequests []CalledRequest
-	mu             sync.Mutex
-	Data           atomic.Value
+	CalledRequests   []CalledRequest
+	ExpectedRequests []ExpectedRequest
+	mu               sync.Mutex
+	Data             atomic.Value
 }
 
 func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturnedFromApi ...string) *TestServer {
@@ -43,9 +52,23 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 
 		if r.Header.Get("Authorization") != "Bearer foo" {
 			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
-			t.Fail()
 		}
 
+		// Check for custom request handlers first
+		ts.mu.Lock()
+		for _, expected := range ts.ExpectedRequests {
+			if expected.Method == r.Method && expected.URL == r.RequestURI {
+				if expected.Body == "" || expected.Body == string(body) {
+					w.WriteHeader(expected.StatusCode)
+					_, _ = w.Write([]byte(expected.Response))
+					ts.mu.Unlock()
+					return
+				}
+			}
+		}
+		ts.mu.Unlock()
+
+		// Fall back to default handlers
 		switch {
 		case r.Method == http.MethodPost && r.RequestURI == baseRequestURI:
 			parsedBody := make(map[string]interface{})
@@ -89,11 +112,22 @@ func newResourceServer(t *testing.T, baseRequestURI, id string, fieldsNotReturne
 			ts.Data.Store([]byte(nil))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
-			t.Fail()
 		}
 	}))
 
 	return ts
+}
+
+func (ts *TestServer) ExpectRequest(method, url, body string, statusCode int, response string) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	ts.ExpectedRequests = append(ts.ExpectedRequests, ExpectedRequest{
+		Method:     method,
+		URL:        url,
+		Body:       body,
+		StatusCode: statusCode,
+		Response:   response,
+	})
 }
 
 func (ts *TestServer) TestCheckCalledRequest(method, url, body string) resource.TestCheckFunc {
@@ -101,7 +135,7 @@ func (ts *TestServer) TestCheckCalledRequest(method, url, body string) resource.
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
 		for _, req := range ts.CalledRequests {
-			if req.Method == method && req.URL == url && req.Body == body {
+			if req.Method == method && req.URL == url && (body == "" || req.Body == body) {
 				return nil
 			}
 		}


### PR DESCRIPTION
Allows managing on-call rotations via Terraform:

```tf
resource "betteruptime_on_call_calendar" "new" {
  name = "My Terraform calendar"
  on_call_rotation {
    users              = ["petr@betterstack.com", "simon@betterstack.com"]
    rotation_length    = 1
    rotation_interval  = "day"
    start_rotations_at = "2025-01-01T00:00:00Z"
    end_rotations_at   = "2026-01-01T00:00:00Z"
  }
}
```