### PR TITLE
[U-3728] Add `expiration_policy_id` attribute to `betteruptime_monitor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.18.0
+VERSION := 0.18.1
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -30,6 +30,7 @@ Monitor lookup.
 - **domain_expiration** (Number) How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
 - **email** (Boolean) Should we send an email to the on-call person?
 - **expected_status_codes** (List of Number) Required if monitor_type is set to expected_status_code. We will create a new incident if the status code returned from the server is not in the list of expected status codes.
+- **expiration_policy_id** (Number) Set the expiration escalation policy for the monitor. It is used for SSL certificate and domain expiration checks. When set to null, an e-mail is sent to the entire team.
 - **follow_redirects** (Boolean) Set to true for the monitor to follow redirects.
 - **http_method** (String) HTTP Method used to make a request. Valid options: GET, HEAD, POST, PUT, PATCH
 - **id** (String) The ID of this Monitor.

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -60,6 +60,7 @@ https://betterstack.com/docs/uptime/api/monitors/
 - **domain_expiration** (Number) How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
 - **email** (Boolean) Should we send an email to the on-call person?
 - **expected_status_codes** (List of Number) Required if monitor_type is set to expected_status_code. We will create a new incident if the status code returned from the server is not in the list of expected status codes.
+- **expiration_policy_id** (Number) Set the expiration escalation policy for the monitor. It is used for SSL certificate and domain expiration checks. When set to null, an e-mail is sent to the entire team.
 - **follow_redirects** (Boolean) Set to true for the monitor to follow redirects.
 - **http_method** (String) HTTP Method used to make a request. Valid options: GET, HEAD, POST, PUT, PATCH
 - **ip_version** (String) Valid values:

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -34,9 +34,10 @@ resource "betteruptime_monitor_group" "this" {
 }
 
 resource "betteruptime_monitor" "status" {
-  url              = "https://example.com"
-  monitor_type     = "status"
-  monitor_group_id = betteruptime_monitor_group.this.id
+  url                  = "https://example.com"
+  monitor_type         = "status"
+  monitor_group_id     = betteruptime_monitor_group.this.id
+  expiration_policy_id = betteruptime_policy.this.id
   request_headers = [
     {
       "name" : "X-For-Status-Page",

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.18.0"
+      version = ">= 0.18.1"
     }
   }
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.18.0"
+      version = ">= 0.18.1"
     }
   }
 }

--- a/examples/catalog/versions.tf
+++ b/examples/catalog/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.18.0"
+      version = ">= 0.18.1"
     }
   }
 }

--- a/examples/ips/versions.tf
+++ b/examples/ips/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.18"
+      version = ">= 0.18.1"
     }
   }
 }

--- a/examples/on_call_calendars/versions.tf
+++ b/examples/on_call_calendars/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.18.0"
+      version = ">= 0.18.1"
     }
   }
 }


### PR DESCRIPTION
The attribute reflects the same attribute in the Monitor API, which was recently added.

Per discussion with @PetrHeinz, `expiration_policy_id` is not computed so it is possible to set it to `null` by users. We also always send its value to the API on create/update, even when it is not set or changed. This is done because we use Go structs + default JSON serialization, meaning it's impossible to differentitate between not setting the attribute and setting it to `null`.