### PR TITLE
U-4963 Fix Escalation policy group configuration

### DIFF
--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -262,6 +262,7 @@ func policyRef(in *policy) []struct {
 		{k: "repeat_delay", v: &in.RepeatDelay},
 		{k: "incident_token", v: &in.IncidentToken},
 		{k: "steps", v: &in.Steps},
+		{k: "policy_group_id", v: &in.PolicyGroupID},
 	}
 }
 


### PR DESCRIPTION
Fixes #110, escalation policy groups were created, but never linked to escalation policies.

Double-checked that all other group ID are handled correctly.