### PR TITLE
Update betteruptime_status_page_resource.md

### DIFF
--- a/docs/resources/betteruptime_status_page_resource.md
+++ b/docs/resources/betteruptime_status_page_resource.md
@@ -19,7 +19,7 @@ https://betterstack.com/docs/uptime/api/status-page-resources/
 
 - `public_name` (String) The resource name displayed publicly on your status page.
 - `resource_id` (Number) The ID of the resource you are adding.
-- `resource_type` (String) The type of the resource you are adding. Available values: Monitor, MonitorGroup, Heartbeat, WebhookIntegration, EmailIntegration, IncomingWebhook.
+- `resource_type` (String) The type of the resource you are adding. Available values: Monitor, MonitorGroup, Heartbeat, HeartbeatGroup, WebhookIntegration, EmailIntegration, IncomingWebhook, ResourceGroup, LogsChart, CatalogReference.
 - `status_page_id` (String) The ID of the Status Page.
 
 ### Optional

--- a/docs/resources/betteruptime_status_page_resource.md
+++ b/docs/resources/betteruptime_status_page_resource.md
@@ -19,7 +19,7 @@ https://betterstack.com/docs/uptime/api/status-page-resources/
 
 - `public_name` (String) The resource name displayed publicly on your status page.
 - `resource_id` (Number) The ID of the resource you are adding.
-- `resource_type` (String) The type of the resource you are adding. Available values: Monitor, Heartbeat, WebhookIntegration, EmailIntegration, IncomingWebhook.
+- `resource_type` (String) The type of the resource you are adding. Available values: Monitor, MonitorGroup, Heartbeat, WebhookIntegration, EmailIntegration, IncomingWebhook.
 - `status_page_id` (String) The ID of the Status Page.
 
 ### Optional

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/url"
 	"reflect"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var statusPageResourceSchema = map[string]*schema.Schema{

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"net/url"
 	"reflect"
 	"strings"
@@ -36,10 +37,10 @@ var statusPageResourceSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"resource_type": {
-		Description: "The type of the resource you are adding. Available values: Monitor, Heartbeat, WebhookIntegration, EmailIntegration, IncomingWebhook.",
-		Type:        schema.TypeString,
-		Required:    true,
-		// TODO: ValidateDiagFunc: validation.StringInSlice
+		Description:  "The type of the resource you are adding. Available values: Monitor, MonitorGroup, Heartbeat, HeartbeatGroup, WebhookIntegration, EmailIntegration, IncomingWebhook, ResourceGroup, LogsChart, CatalogReference.",
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"Monitor", "MonitorGroup", "Heartbeat", "HeartbeatGroup", "WebhookIntegration", "EmailIntegration", "IncomingWebhook", "ResourceGroup", "LogsChart", "CatalogReference"}, false),
 	},
 	"public_name": {
 		Description: "The resource name displayed publicly on your status page.",


### PR DESCRIPTION
Added `MonitorGroup` to `resource_type` options, as defined in [the API spec](https://betterstack.com/docs/uptime/api/create-a-new-status-page-resource/)

Related to https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/146