### PR TITLE
[U-4578] Use ESM import syntax in Playwright monitor example

### DIFF
--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -58,7 +58,7 @@ resource "betteruptime_monitor" "playwright" {
   monitor_type      = "playwright"
   monitor_group_id  = betteruptime_monitor_group.this.id
   playwright_script = <<-EOT
-    const { test, expect } = require('@playwright/test');
+    import { test, expect } from '@playwright/test';
 
     test('has title and e-mail', async ({ page }) => {
       await page.goto('https://betterstack.com/')


### PR DESCRIPTION
This reflects a similar update of the default Playwright scenario in the app.