### PR TITLE
U-3893 Avoid de-assigning policy from Heartbeats on subsequent patches

### DIFF
--- a/internal/provider/resource_heartbeat.go
+++ b/internal/provider/resource_heartbeat.go
@@ -200,7 +200,7 @@ type heartbeat struct {
 	MaintenanceDays     *[]string `json:"maintenance_days,omitempty"`
 	Paused              *bool     `json:"paused,omitempty"`
 	PausedAt            *string   `json:"paused_at,omitempty"`
-	PolicyID            *string   `json:"policy_id"`
+	PolicyID            *string   `json:"policy_id,omitempty"`
 	Status              *string   `json:"status,omitempty"`
 	CreatedAt           *string   `json:"created_at,omitempty"`
 	UpdatedAt           *string   `json:"updated_at,omitempty"`

--- a/internal/provider/resource_heartbeat.go
+++ b/internal/provider/resource_heartbeat.go
@@ -145,7 +145,6 @@ var heartbeatSchema = map[string]*schema.Schema{
 		Description: "Set the escalation policy for the heartbeat.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"status": {
 		Description: "The status of this heartbeat.",

--- a/internal/provider/resource_heartbeat_test.go
+++ b/internal/provider/resource_heartbeat_test.go
@@ -64,6 +64,7 @@ func TestResourceHeartbeat(t *testing.T) {
 					name           = "%s"
 					period         = 31
 					grace          = 1
+					policy_id      = 123
 					call           = true
 					sms            = false
 					email          = true
@@ -76,11 +77,45 @@ func TestResourceHeartbeat(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "name", name),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "period", "31"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "grace", "1"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "policy_id", "123"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "call", "true"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "sms", "false"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "email", "true"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "push", "true"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "critical_alert", "true"),
+				),
+			},
+			// Step 4 - change only period, expect only it be patched
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_heartbeat" "this" {
+					name           = "%s"
+					period         = 45
+					grace          = 1
+					policy_id      = 123
+					call           = true
+					sms            = false
+					email          = true
+					push           = true
+					critical_alert = true
+				}
+				`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_heartbeat.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "name", name),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "period", "45"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "grace", "1"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "policy_id", "123"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "call", "true"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "sms", "false"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "email", "true"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "push", "true"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "critical_alert", "true"),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"period":45}`),
 				),
 			},
 			// Step 3 - make no changes, check plan is empty.
@@ -92,8 +127,9 @@ func TestResourceHeartbeat(t *testing.T) {
 
 				resource "betteruptime_heartbeat" "this" {
 					name           = "%s"
-					period         = 31
+					period         = 45
 					grace          = 1
+					policy_id      = 123
 					call           = true
 					sms            = false
 					email          = true

--- a/internal/provider/resource_heartbeat_test.go
+++ b/internal/provider/resource_heartbeat_test.go
@@ -118,7 +118,7 @@ func TestResourceHeartbeat(t *testing.T) {
 					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"period":45}`),
 				),
 			},
-			// Step 3 - make no changes, check plan is empty.
+			// Step 5 - remove policy_id, expect only it be de-assigned
 			{
 				Config: fmt.Sprintf(`
 				provider "betteruptime" {
@@ -129,7 +129,38 @@ func TestResourceHeartbeat(t *testing.T) {
 					name           = "%s"
 					period         = 45
 					grace          = 1
-					policy_id      = 123
+					call           = true
+					sms            = false
+					email          = true
+					push           = true
+					critical_alert = true
+				}
+				`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_heartbeat.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "name", name),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "period", "45"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "grace", "1"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "policy_id", ""),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "call", "true"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "sms", "false"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "email", "true"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "push", "true"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "critical_alert", "true"),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"policy_id":null}`),
+				),
+			},
+			// Step 6 - make no changes, check plan is empty.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_heartbeat" "this" {
+					name           = "%s"
+					period         = 45
+					grace          = 1
 					call           = true
 					sms            = false
 					email          = true
@@ -139,7 +170,7 @@ func TestResourceHeartbeat(t *testing.T) {
 				`, name),
 				PlanOnly: true,
 			},
-			// Step 4 - destroy.
+			// Step 7 - destroy.
 			{
 				ResourceName:      "betteruptime_heartbeat.this",
 				ImportState:       true,

--- a/internal/provider/resource_heartbeat_test.go
+++ b/internal/provider/resource_heartbeat_test.go
@@ -147,7 +147,7 @@ func TestResourceHeartbeat(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "email", "true"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "push", "true"),
 					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "critical_alert", "true"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"policy_id":null}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"policy_id":""}`), // Understood as null by API
 				),
 			},
 			// Step 6 - make no changes, check plan is empty.


### PR DESCRIPTION
Created a heartbeat:

```
resource "betteruptime_heartbeat" "this" {
  name      = "Testing heartbeat"
  period    = 30
  grace     = 0
  paused    = true
  policy_id = "98930"
}
```

Seems to be created correctly:

![image](https://github.com/user-attachments/assets/11ec08c8-d63d-4f76-987b-5506889fe441)

Unpaused it:

```
Terraform will perform the following actions:

  # betteruptime_heartbeat.this will be updated in-place
  ~ resource "betteruptime_heartbeat" "this" {
        id                   = "420552"
        name                 = "Testing heartbeat"
      ~ paused               = true -> false
        # (20 unchanged attributes hidden)
    }
```

The escalation policy got lost 🙈 

![image](https://github.com/user-attachments/assets/1012faf0-5175-4461-a881-af1883c345d8)

Would get set correctly on reapply:

```
Terraform will perform the following actions:

  # betteruptime_heartbeat.this will be updated in-place
  ~ resource "betteruptime_heartbeat" "this" {
        id                   = "420552"
        name                 = "Testing heartbeat"
      + policy_id            = "98930"
        # (20 unchanged attributes hidden)
    }
```

This is true for any change, if policy ID isn' changed, it will get lost.

This is a Terraform bug, sends e.g. `PATCH /api/v2/heartbeats/420552: {"period":30,"policy_id":null}`

---

Fixed by sending the ID only on change, `""` is understood as `null` by the API ✅ 