### PR TITLE
U-4557 [monitor] Allow disabling domain_expiration and ssl_expiration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.19.3
+VERSION := 0.19.8
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -28,7 +28,7 @@ Monitor lookup.
 - `confirmation_period` (Number) How long should we wait after observing a failure before we start a new incident? In seconds.
 - `created_at` (String) The time when this monitor was created.
 - `critical_alert` (Boolean) Whether to send a critical push notification that ignores the mute switch and Do not Disturb mode when a new incident is created.
-- `domain_expiration` (Number) How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
+- `domain_expiration` (Number) How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable domain expiration check.
 - `email` (Boolean) Whether to send an email when a new incident is created.
 - `environment_variables` (Map of String, Sensitive) For Playwright monitors, the environment variables that can be used in the scenario. Example: `{ "PASSWORD" = "passw0rd" }`.
 - `expected_status_codes` (List of Number) Required if monitor_type is set to expected_status_code. We will create a new incident if the status code returned from the server is not in the list of expected status codes.
@@ -97,7 +97,7 @@ Monitor lookup.
 - `required_keyword` (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
+- `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable SSL expiration check.
 - `status` (String) The status of this website check.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team. In seconds.
 - `updated_at` (String) The time when this monitor was updated.

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -58,7 +58,7 @@ https://betterstack.com/docs/uptime/api/monitors/
 - `check_frequency` (Number) How often should we check your website? In seconds.
 - `confirmation_period` (Number) How long should we wait after observing a failure before we start a new incident? In seconds.
 - `critical_alert` (Boolean) Whether to send a critical push notification that ignores the mute switch and Do not Disturb mode when a new incident is created.
-- `domain_expiration` (Number) How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
+- `domain_expiration` (Number) How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable domain expiration check.
 - `email` (Boolean) Whether to send an email when a new incident is created.
 - `environment_variables` (Map of String, Sensitive) For Playwright monitors, the environment variables that can be used in the scenario. Example: `{ "PASSWORD" = "passw0rd" }`.
 - `expected_status_codes` (List of Number) Required if monitor_type is set to expected_status_code. We will create a new incident if the status code returned from the server is not in the list of expected status codes.
@@ -93,7 +93,7 @@ https://betterstack.com/docs/uptime/api/monitors/
 - `required_keyword` (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
 - `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
+- `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable SSL expiration check.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team. In seconds.
 - `verify_ssl` (Boolean) Should we verify SSL certificate validity?

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -38,8 +38,8 @@ resource "betteruptime_monitor" "status" {
   monitor_type         = "status"
   monitor_group_id     = betteruptime_monitor_group.this.id
   expiration_policy_id = betteruptime_policy.this.id
-  domain_expiration    = -1  # Disable domain expiration check
-  ssl_expiration       = -1  # Disable SSL expiration check
+  domain_expiration    = -1 # Disable domain expiration check
+  ssl_expiration       = -1 # Disable SSL expiration check
   request_headers = [
     {
       "name" : "X-For-Status-Page",

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -38,6 +38,8 @@ resource "betteruptime_monitor" "status" {
   monitor_type         = "status"
   monitor_group_id     = betteruptime_monitor_group.this.id
   expiration_policy_id = betteruptime_policy.this.id
+  domain_expiration    = -1  # Disable domain expiration check
+  ssl_expiration       = -1  # Disable SSL expiration check
   request_headers = [
     {
       "name" : "X-For-Status-Page",

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.19.3"
+      version = ">= 0.19.8"
     }
   }
 }

--- a/internal/provider/data_monitor.go
+++ b/internal/provider/data_monitor.go
@@ -22,6 +22,7 @@ func newMonitorDataSource() *schema.Resource {
 			cp.Computed = true
 			cp.Optional = false
 			cp.Required = false
+			cp.ValidateFunc = nil
 			cp.ValidateDiagFunc = nil
 			cp.Default = nil
 			cp.DefaultFunc = nil

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -564,18 +564,6 @@ func monitorRef(in *monitor) []struct {
 	}
 }
 
-// loadNullableInt handles conversion of special values to nil for various fields.
-func loadNullableInt(d *schema.ResourceData, fieldName string, receiver **int, nullValue int) {
-	if v, ok := d.GetOk(fieldName); ok {
-		t := v.(int)
-		if t == nullValue {
-			*receiver = nil
-		} else {
-			*receiver = &t
-		}
-	}
-}
-
 func monitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in monitor
 	for _, e := range monitorRef(&in) {

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -606,9 +606,13 @@ func monitorCopyAttrs(d *schema.ResourceData, in *monitor) diag.Diagnostics {
 	var derr diag.Diagnostics
 	for _, e := range monitorRef(in) {
 		if e.k == "ssl_expiration" {
-			SetNullableIntResourceData(d, "ssl_expiration", -1, in.SSLExpiration)
+			if err := SetNullableIntResourceData(d, "ssl_expiration", -1, in.SSLExpiration); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		} else if e.k == "domain_expiration" {
-			SetNullableIntResourceData(d, "domain_expiration", -1, in.DomainExpiration)
+			if err := SetNullableIntResourceData(d, "domain_expiration", -1, in.DomainExpiration); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		} else if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 			derr = append(derr, diag.FromErr(err)[0])
 		}

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -454,62 +453,11 @@ func newMonitorResource() *schema.Resource {
 	}
 }
 
-// NullableInt is a custom type that handles special JSON marshaling for nullable integer fields.
-// When the value is -1, it will be marshaled as null.
-// When the value is not set, the field will be omitted from JSON.
-type NullableInt struct {
-	Value *int
-	// Set to true when the field is explicitly set to -1
-	IsSet bool
-}
-
-func (n NullableInt) MarshalJSON() ([]byte, error) {
-	if n.Value == nil {
-		if n.IsSet {
-			return []byte("null"), nil
-		}
-		return []byte("null"), nil
-	}
-	return json.Marshal(*n.Value)
-}
-
-func (n *NullableInt) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		n.Value = nil
-		n.IsSet = true
-		return nil
-	}
-	var v int
-	if err := json.Unmarshal(data, &v); err != nil {
-		return err
-	}
-	n.Value = &v
-	n.IsSet = true
-	return nil
-}
-
-// loadNullableIntField handles loading a value into a NullableInt field.
-func loadNullableIntField(d *schema.ResourceData, fieldName string, receiver *NullableInt) {
-	if v, ok := d.GetOk(fieldName); ok {
-		t := v.(int)
-		if t == -1 {
-			receiver.Value = nil
-			receiver.IsSet = true
-		} else {
-			receiver.Value = &t
-			receiver.IsSet = true
-		}
-	} else {
-		receiver.Value = nil
-		receiver.IsSet = false
-	}
-}
-
 type monitor struct {
 	SSLExpiration        *NullableInt              `json:"ssl_expiration,omitempty"`
 	DomainExpiration     *NullableInt              `json:"domain_expiration,omitempty"`
 	PolicyID             *string                   `json:"policy_id,omitempty"`
-	ExpirationPolicyID   *int                      `json:"expiration_policy_id,omitempty"`
+	ExpirationPolicyID   *int                      `json:"expiration_policy_id"`
 	URL                  *string                   `json:"url,omitempty"`
 	MonitorType          *string                   `json:"monitor_type,omitempty"`
 	RequiredKeyword      *string                   `json:"required_keyword,omitempty"`
@@ -636,16 +584,10 @@ func monitorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}
 				return diag.FromErr(err)
 			}
 		} else if e.k == "expiration_policy_id" {
-			// Represent null value as 0 for expiration_policy_id
-			loadNullableInt(d, e.k, e.v.(**int), 0)
+			// Work around the fact that Terraform represents null value as 0
+			loadExpirationPolicy(d, e.v.(**int))
 		} else if e.k == "domain_expiration" || e.k == "ssl_expiration" {
-			var ni NullableInt
-			loadNullableIntField(d, e.k, &ni)
-			if ni.IsSet {
-				*e.v.(**NullableInt) = &ni
-			} else {
-				*e.v.(**NullableInt) = nil
-			}
+			*e.v.(**NullableInt) = NullableIntFromResource(d, e.k)
 			continue
 		} else {
 			load(d, e.k, e.v)
@@ -675,18 +617,18 @@ func monitorCopyAttrs(d *schema.ResourceData, in *monitor) diag.Diagnostics {
 	var derr diag.Diagnostics
 	for _, e := range monitorRef(in) {
 		if e.k == "ssl_expiration" {
-			if in.SSLExpiration == nil || in.SSLExpiration.Value == nil {
+			if in.SSLExpiration == nil {
 				d.Set("ssl_expiration", -1)
 			} else {
-				d.Set("ssl_expiration", *in.SSLExpiration.Value)
+				d.Set("ssl_expiration", in.SSLExpiration.ToTerraform())
 			}
 			continue
 		}
 		if e.k == "domain_expiration" {
-			if in.DomainExpiration == nil || in.DomainExpiration.Value == nil {
+			if in.DomainExpiration == nil {
 				d.Set("domain_expiration", -1)
 			} else {
-				d.Set("domain_expiration", *in.DomainExpiration.Value)
+				d.Set("domain_expiration", in.DomainExpiration.ToTerraform())
 			}
 			continue
 		}
@@ -702,16 +644,10 @@ func monitorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}
 	var out policyHTTPResponse
 	for _, e := range monitorRef(&in) {
 		if e.k == "expiration_policy_id" {
-			// Represent null value as 0 for expiration_policy_id
-			loadNullableInt(d, e.k, e.v.(**int), 0)
+			// Work around the fact that Terraform represents null value as 0
+			loadExpirationPolicy(d, e.v.(**int))
 		} else if (e.k == "domain_expiration" || e.k == "ssl_expiration") && d.HasChange(e.k) {
-			var ni NullableInt
-			loadNullableIntField(d, e.k, &ni)
-			if ni.IsSet {
-				*e.v.(**NullableInt) = &ni
-			} else {
-				*e.v.(**NullableInt) = nil
-			}
+			*e.v.(**NullableInt) = NullableIntFromResource(d, e.k)
 			continue
 		} else if d.HasChange(e.k) {
 			if e.k == "request_headers" {
@@ -826,4 +762,15 @@ func findRequestHeader(headers *[]map[string]interface{}, header *map[string]int
 		}
 	}
 	return nil
+}
+
+func loadExpirationPolicy(d *schema.ResourceData, receiver **int) {
+	if v, ok := d.GetOk("expiration_policy_id"); ok {
+		t := v.(int)
+		if t == 0 {
+			*receiver = nil
+		} else {
+			*receiver = &t
+		}
+	}
 }

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -637,7 +637,7 @@ func TestResourceMonitorWithDomainExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
-					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"url":"http://example.com","monitor_type":"status","request_headers":null}`),
+					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","request_headers":null}`),
 				),
 			},
 			// Step 2 - update (set to non-null value).
@@ -657,7 +657,7 @@ func TestResourceMonitorWithDomainExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "domain_expiration", "7"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"domain_expiration":7}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"domain_expiration":7,"expiration_policy_id":null}`),
 				),
 			},
 			// Step 3 - update (set to null).
@@ -678,7 +678,7 @@ func TestResourceMonitorWithDomainExpiration(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "domain_expiration", "-1"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"domain_expiration":null}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"domain_expiration":null,"expiration_policy_id":null}`),
 				),
 			},
 			// Step 4 - update (set to non-null value again).
@@ -698,7 +698,7 @@ func TestResourceMonitorWithDomainExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "domain_expiration", "14"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"domain_expiration":14}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"domain_expiration":14,"expiration_policy_id":null}`),
 				),
 			},
 			// Step 5 - update (unset).
@@ -760,7 +760,7 @@ func TestResourceMonitorWithSSLExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
-					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"url":"http://example.com","monitor_type":"status","request_headers":null}`),
+					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","request_headers":null}`),
 				),
 			},
 			// Step 2 - update (set to non-null value).
@@ -780,7 +780,7 @@ func TestResourceMonitorWithSSLExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "ssl_expiration", "7"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"ssl_expiration":7}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"ssl_expiration":7,"expiration_policy_id":null}`),
 				),
 			},
 			// Step 3 - update (set to null).
@@ -801,7 +801,7 @@ func TestResourceMonitorWithSSLExpiration(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "ssl_expiration", "-1"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"ssl_expiration":null}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"ssl_expiration":null,"expiration_policy_id":null}`),
 				),
 			},
 			// Step 4 - update (set to non-null value again).
@@ -821,7 +821,7 @@ func TestResourceMonitorWithSSLExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "ssl_expiration", "14"),
-					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"ssl_expiration":14}`),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/monitors/1", `{"ssl_expiration":14,"expiration_policy_id":null}`),
 				),
 			},
 			// Step 5 - update (unset).

--- a/internal/provider/type_nullable_int.go
+++ b/internal/provider/type_nullable_int.go
@@ -96,10 +96,9 @@ func NullableIntFromResourceData(d *schema.ResourceData, key string, terraformNu
 // Example from resource_monitor.go:
 //
 //	SetNullableIntResourceData(d, "ssl_expiration", -1, in.SSLExpiration)
-func SetNullableIntResourceData(d *schema.ResourceData, key string, terraformNullValue int, nullableInt *NullableInt) {
+func SetNullableIntResourceData(d *schema.ResourceData, key string, terraformNullValue int, nullableInt *NullableInt) error {
 	if nullableInt == nil || nullableInt.ExplicitNull {
-		d.Set(key, terraformNullValue)
-	} else if nullableInt.Value != nil {
-		d.Set(key, *nullableInt.Value)
+		return d.Set(key, terraformNullValue)
 	}
+	return d.Set(key, *nullableInt.Value)
 }

--- a/internal/provider/type_nullable_int.go
+++ b/internal/provider/type_nullable_int.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"encoding/json"
+)
+
+// NullableInt is a custom type that handles special JSON marshaling for nullable integer fields.
+// It is designed to handle three states:
+// 1. Unset (field is omitted from JSON)
+// 2. ExplicitNull = true (field is sent as null in JSON, i.e. set to -1 in Terraform)
+// 3. Value is set (field is sent as that value in JSON)
+//
+// Example usage:
+//
+//	type Monitor struct {
+//	    SSLExpiration *NullableInt `json:"ssl_expiration,omitempty"`
+//	}
+//
+//	// When unset in Terraform:
+//	// JSON: {} (field is omitted)
+//	// Terraform: field is not set
+//
+//	// When set to -1 in Terraform:
+//	// JSON: {"ssl_expiration": null}
+//	// Terraform: ssl_expiration = -1
+//
+//	// When set to 7 in Terraform:
+//	// JSON: {"ssl_expiration": 7}
+//	// Terraform: ssl_expiration = 7
+type NullableInt struct {
+	// Value is the actual integer value. When nil and ExplicitNull is false, the field is omitted.
+	Value *int
+	// ExplicitNull indicates whether the field should be marshaled as null (set to -1 in Terraform).
+	ExplicitNull bool
+}
+
+// MarshalJSON implements json.Marshaler interface.
+// If ExplicitNull is true, returns "null".
+// If Value is set, returns the value as JSON.
+// If neither, returns nil (field is omitted).
+func (n NullableInt) MarshalJSON() ([]byte, error) {
+	if n.ExplicitNull {
+		return []byte("null"), nil
+	}
+	if n.Value != nil {
+		return json.Marshal(*n.Value)
+	}
+	return nil, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+// When the JSON value is "null", sets ExplicitNull to true.
+// Otherwise, unmarshals the value into Value.
+func (n *NullableInt) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		n.Value = nil
+		n.ExplicitNull = true
+		return nil
+	}
+	var v int
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	n.Value = &v
+	n.ExplicitNull = false
+	return nil
+}
+
+// LoadFromTerraform loads a value from Terraform into a NullableInt.
+// If the field is not set in Terraform, sets Value to nil and ExplicitNull to false.
+// If the field is set to -1, sets Value to nil and ExplicitNull to true.
+// Otherwise, sets Value to the field's value and ExplicitNull to false.
+func (n *NullableInt) LoadFromTerraform(value interface{}) {
+	if value == nil {
+		n.Value = nil
+		n.ExplicitNull = false
+		return
+	}
+	v := value.(int)
+	if v == -1 {
+		n.Value = nil
+		n.ExplicitNull = true
+	} else {
+		n.Value = &v
+		n.ExplicitNull = false
+	}
+}
+
+// ToTerraform converts a NullableInt to a Terraform value.
+// If ExplicitNull is true, returns -1 (field was set to -1).
+// If Value is nil and ExplicitNull is false, returns nil (field is unset).
+// Otherwise, returns the value.
+func (n *NullableInt) ToTerraform() interface{} {
+	if n.ExplicitNull {
+		return -1
+	}
+	if n.Value == nil {
+		return nil
+	}
+	return *n.Value
+}
+
+// NewNullableIntFromTerraform returns a pointer to a NullableInt based on the Terraform value.
+// Returns nil if the field is not set.
+func NewNullableIntFromTerraform(value interface{}) *NullableInt {
+	if value == nil {
+		return nil
+	}
+	ni := &NullableInt{}
+	ni.LoadFromTerraform(value)
+	return ni
+}
+
+// NullableIntFromResource returns a pointer to a NullableInt from a ResourceData key, or nil if not set.
+func NullableIntFromResource(d interface {
+	GetOk(string) (interface{}, bool)
+}, key string) *NullableInt {
+	if v, ok := d.GetOk(key); ok {
+		return NewNullableIntFromTerraform(v)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/122 

Both `domain_expiration` and `ssl_expiration` fields can now be set to `-1` to disable the check for that particular monitor.

It was important to keep the logic of `nil` in Terraform meaning "no change", because monitors with the same URL for monitoring are effectively sharing this value. If we didn't support it, adding a new monitor resource without specifying the `domain_expiration` could destabilize plan phase (switching the value between `null` and explicit value in other monitor)