### PR TITLE
U-6630 Allow creating Playwright monitors with scenario_name, no url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.1
+VERSION := 0.20.2
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -17,7 +17,7 @@ Monitor lookup.
 
 ### Required
 
-- `url` (String) URL of your website or the host you want to ping (see monitor_type below).
+- `url` (String) URL of your website or the host you want to ping (see monitor_type below). Required for all monitor types except Playwright. For Playwright monitors, either `url` or `scenario_name` must be provided.
 
 ### Read-Only
 
@@ -95,7 +95,7 @@ Monitor lookup.
   - For Playwright monitors (type `playwright`), this determines the Playwright scenario timeout instead in *seconds*. Valid options: 15, 30, 45, 60.
   - For all other monitors, the timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
 - `required_keyword` (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
-- `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI.
+- `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI. For Playwright monitors, either `url` or `scenario_name` must be provided.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable SSL expiration check.
 - `status` (String) The status of this website check.

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -48,7 +48,6 @@ https://betterstack.com/docs/uptime/api/monitors/
 (request_body is required, and should contain the domain to query the DNS server with).
 
     `playwright` We will run the scenario defined by playwright_script, identified in the UI by scenario_name
-- `url` (String) URL of your website or the host you want to ping (see monitor_type below).
 
 ### Optional
 
@@ -91,11 +90,12 @@ https://betterstack.com/docs/uptime/api/monitors/
   - For Playwright monitors (type `playwright`), this determines the Playwright scenario timeout instead in *seconds*. Valid options: 15, 30, 45, 60.
   - For all other monitors, the timeout is specified in *seconds*. Valid options: 2, 3, 5, 10, 15, 30, 45, 60.
 - `required_keyword` (String) Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.
-- `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI.
+- `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI. For Playwright monitors, either `url` or `scenario_name` must be provided.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable SSL expiration check.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team. In seconds.
+- `url` (String) URL of your website or the host you want to ping (see monitor_type below). Required for all monitor types except Playwright. For Playwright monitors, either `url` or `scenario_name` must be provided.
 - `verify_ssl` (Boolean) Should we verify SSL certificate validity?
 
 ### Read-Only

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -71,7 +71,7 @@ resource "betteruptime_monitor" "dns" {
 }
 
 resource "betteruptime_monitor" "playwright" {
-  url               = "Better Stack Homepage"
+  script_name       = "Better Stack Homepage"
   monitor_type      = "playwright"
   monitor_group_id  = betteruptime_monitor_group.this.id
   playwright_script = <<-EOT

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -71,7 +71,7 @@ resource "betteruptime_monitor" "dns" {
 }
 
 resource "betteruptime_monitor" "playwright" {
-  script_name       = "Better Stack Homepage"
+  scenario_name     = "Better Stack Homepage"
   monitor_type      = "playwright"
   monitor_group_id  = betteruptime_monitor_group.this.id
   playwright_script = <<-EOT

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.1"
+      version = ">= 0.20.2"
     }
   }
 }

--- a/internal/provider/data_monitor.go
+++ b/internal/provider/data_monitor.go
@@ -17,7 +17,8 @@ func newMonitorDataSource() *schema.Resource {
 		cp := *v
 		switch k {
 		case "url":
-			// keep required
+			cp.Optional = false
+			cp.Required = true
 		default:
 			cp.Computed = true
 			cp.Optional = false

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -61,9 +61,9 @@ var monitorSchema = map[string]*schema.Schema{
 		Default:     nil,
 	},
 	"url": {
-		Description: "URL of your website or the host you want to ping (see monitor_type below).",
+		Description: "URL of your website or the host you want to ping (see monitor_type below). Required for all monitor types except Playwright. For Playwright monitors, either `url` or `scenario_name` must be provided.",
 		Type:        schema.TypeString,
-		Required:    true,
+		Optional:    true,
 	},
 	"monitor_type": {
 		Description: strings.ReplaceAll(`Valid values:
@@ -397,10 +397,9 @@ var monitorSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"scenario_name": {
-		Description: "For Playwright monitors, the scenario name identifying the monitor in the UI.",
+		Description: "For Playwright monitors, the scenario name identifying the monitor in the UI. For Playwright monitors, either `url` or `scenario_name` must be provided.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"environment_variables": {
 		Description: "For Playwright monitors, the environment variables that can be used in the scenario. Example: `{ \"PASSWORD\" = \"passw0rd\" }`.",
@@ -447,7 +446,7 @@ func newMonitorResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: validateMonitor,
 		Description:   "https://betterstack.com/docs/uptime/api/monitors/",
 		Schema:        monitorSchema,
 	}
@@ -658,6 +657,30 @@ func validateRequestHeaders(ctx context.Context, diff *schema.ResourceDiff, v in
 			}
 		}
 	}
+	return nil
+}
+
+func validateMonitor(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	// Validate request headers
+	if err := validateRequestHeaders(ctx, diff, v); err != nil {
+		return err
+	}
+
+	// Validate URL requirement based on monitor type
+	monitorType := diff.Get("monitor_type").(string)
+	if monitorType == "playwright" {
+		monitorUrl := diff.Get("url").(string)
+		scenarioName := diff.Get("scenario_name").(string)
+		if monitorUrl == "" && scenarioName == "" {
+			return fmt.Errorf("'scenario_name' (alternatively, you can use 'url') is required for monitor type '%s'", monitorType)
+		}
+	} else {
+		monitorUrl := diff.Get("url").(string)
+		if monitorUrl == "" {
+			return fmt.Errorf("'url' is required for monitor type '%s'", monitorType)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -951,7 +951,7 @@ func TestResourceMonitorValidationErrors(t *testing.T) {
 					playwright_script = "console.log('test')"
 				}
 				`,
-				ExpectError: regexp.MustCompile("'scenario_name' \\(alternatively, you can use 'url'\\) is required for monitor type 'playwright'"),
+				ExpectError: regexp.MustCompile(`'scenario_name' \(alternatively, you can use 'url'\) is required for monitor type 'playwright'`),
 			},
 			// Test non-playwright monitor without URL (should fail)
 			{

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -852,6 +852,124 @@ func TestResourceMonitorWithSSLExpiration(t *testing.T) {
 	})
 }
 
+func TestResourceMonitorPlaywrightValidation(t *testing.T) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Test playwright monitor with scenario_name only (should succeed)
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type      = "playwright"
+					scenario_name     = "test-scenario"
+					playwright_script = "console.log('test')"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", "playwright"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "scenario_name", "test-scenario"),
+				),
+			},
+			// Test playwright monitor with URL only (should succeed)
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type      = "playwright"
+					url               = "https://example.com"
+					playwright_script = "console.log('test')"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", "playwright"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", "https://example.com"),
+				),
+			},
+			// Test playwright monitor with both URL and scenario_name (should succeed)
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type      = "playwright"
+					url               = "https://example.com"
+					scenario_name     = "test-scenario"
+					playwright_script = "console.log('test')"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", "playwright"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", "https://example.com"),
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "scenario_name", "test-scenario"),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceMonitorValidationErrors(t *testing.T) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Test playwright monitor without URL or scenario_name (should fail)
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type      = "playwright"
+					playwright_script = "console.log('test')"
+				}
+				`,
+				ExpectError: regexp.MustCompile("'scenario_name' \\(alternatively, you can use 'url'\\) is required for monitor type 'playwright'"),
+			},
+			// Test non-playwright monitor without URL (should fail)
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type = "status"
+				}
+				`,
+				ExpectError: regexp.MustCompile("'url' is required for monitor type 'status'"),
+			},
+		},
+	})
+}
+
 func TestResourceMonitorWithDisabledExpirationChecks(t *testing.T) {
 	server := createTestServer(t)
 	defer server.Close()


### PR DESCRIPTION
Playwright scripts should be named using scenario_name. There's no point in having `url` as required parameter then.

Test for https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/165