### PR TITLE
U-7085 [monitor] Set strict defaults for parameters essential for monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.2
+VERSION := 0.20.4
 .PHONY: test build
 
 help:

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -120,7 +120,6 @@ var monitorSchema = map[string]*schema.Schema{
 		Description: "Required if monitor_type is set to keyword  or udp. We will create a new incident if this keyword is missing on your page.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"expected_status_codes": {
 		Description: "Required if monitor_type is set to expected_status_code. We will create a new incident if the status code returned from the server is not in the list of expected status codes.",
@@ -129,7 +128,6 @@ var monitorSchema = map[string]*schema.Schema{
 			Type: schema.TypeInt,
 		},
 		Optional: true,
-		Computed: true,
 	},
 	"call": {
 		Description: "Whether to call when a new incident is created.",
@@ -190,7 +188,6 @@ var monitorSchema = map[string]*schema.Schema{
 			" tcp and udp monitors accept any ports, while smtp, pop, and imap accept only the specified ports corresponding with their servers (e.g. \"25,465,587\" for smtp).",
 		Type:     schema.TypeString,
 		Optional: true,
-		Computed: true,
 	},
 	"regions": {
 		Description: "An array of regions to set. Allowed values are [\"us\", \"eu\", \"as\", \"au\"] or any subset of these regions.",
@@ -245,7 +242,7 @@ var monitorSchema = map[string]*schema.Schema{
 		Description: "HTTP Method used to make a request. Valid options: GET, HEAD, POST, PUT, PATCH",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
+		Default:     "GET",
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			return strings.EqualFold(old, new)
 		},
@@ -264,7 +261,6 @@ var monitorSchema = map[string]*schema.Schema{
 		Description: "Request body for POST, PUT, PATCH requests. Required if monitor_type is set to dns (domain to query the DNS server with).",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"request_headers": {
 		Description: "An array of request headers, consisting of name and value pairs",
@@ -276,7 +272,6 @@ var monitorSchema = map[string]*schema.Schema{
 			},
 		},
 		Optional: true,
-		Computed: true,
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			// Ignore ID changes
 			attribute := strings.Split(k, ".")
@@ -291,14 +286,12 @@ var monitorSchema = map[string]*schema.Schema{
 		Description: "Basic HTTP authentication username to include with the request.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 		Sensitive:   true,
 	},
 	"auth_password": {
 		Description: "Basic HTTP authentication password to include with the request.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 		Sensitive:   true,
 	},
 
@@ -394,7 +387,6 @@ var monitorSchema = map[string]*schema.Schema{
 		Description: "For Playwright monitors, the JavaScript source code of the scenario.",
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
 	},
 	"scenario_name": {
 		Description: "For Playwright monitors, the scenario name identifying the monitor in the UI. For Playwright monitors, either `url` or `scenario_name` must be provided.",

--- a/internal/provider/resource_monitor_test.go
+++ b/internal/provider/resource_monitor_test.go
@@ -336,7 +336,7 @@ func TestResourceMonitorWithExpirationPolicyId(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "expiration_policy_id", "0"),
-					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","request_headers":null}`),
+					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","http_method":"GET","request_headers":null}`),
 				),
 			},
 			// Step 2 - update (set to non-null value).
@@ -637,7 +637,7 @@ func TestResourceMonitorWithDomainExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
-					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","request_headers":null}`),
+					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","http_method":"GET","request_headers":null}`),
 				),
 			},
 			// Step 2 - update (set to non-null value).
@@ -760,7 +760,7 @@ func TestResourceMonitorWithSSLExpiration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("betteruptime_monitor.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "url", url),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
-					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","request_headers":null}`),
+					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","http_method":"GET","request_headers":null}`),
 				),
 			},
 			// Step 2 - update (set to non-null value).
@@ -1014,7 +1014,7 @@ func TestResourceMonitorWithDisabledExpirationChecks(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", monitorType),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "ssl_expiration", "-1"),
 					resource.TestCheckResourceAttr("betteruptime_monitor.this", "domain_expiration", "-1"),
-					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"ssl_expiration":null,"domain_expiration":null,"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","request_headers":null}`),
+					server.TestCheckCalledRequest("POST", "/api/v2/monitors", `{"ssl_expiration":null,"domain_expiration":null,"expiration_policy_id":null,"url":"http://example.com","monitor_type":"status","http_method":"GET","request_headers":null}`),
 				),
 			},
 		},


### PR DESCRIPTION
Such parameters shouldn't be optional-computed, as there is no reasonable use case for managing these values in UI only.

Previously, these values cannot be emptied easily, which could lead to errors. For example, POST monitor with request_body cannot be changed to GET monitor without request_body, as the parameter would just keep the existing value. API would then throw `Error: PATCH https://uptime.betterstack.com/api/v2/monitors/12345 returned 422: {"errors":{"base":["Request body must be empty when using the HEAD or GET HTTP method`
