### PR TITLE
U-4811 Control advanced settings for Status page resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.4
+VERSION := 0.20.5
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_status_page_resource.md
+++ b/docs/resources/betteruptime_status_page_resource.md
@@ -26,6 +26,10 @@ https://betterstack.com/docs/uptime/api/status-page-resources/
 
 - `explanation` (String) A detailed text displayed as a help icon.
 - `history` (Boolean, Deprecated) Do you want to display detailed historical status for this item? This field is deprecated, use widget_type instead.
+- `mark_as_degraded_for` (String) How to mark this resource as degraded. Can be one of `no_incident`, `any_incident`, or `incident_matching_metadata`.
+- `mark_as_degraded_metadata_rule` (Block List, Max: 1) Metadata rule for marking resource as degraded. Only applicable when mark_as_degraded_for is 'incident_matching_metadata'. (see [below for nested schema](#nestedblock--mark_as_degraded_metadata_rule))
+- `mark_as_down_for` (String) How to mark this resource as down. Can be one of `no_incident`, `any_incident`, or `incident_matching_metadata`.
+- `mark_as_down_metadata_rule` (Block List, Max: 1) Metadata rule for marking resource as down. Only applicable when mark_as_down_for is 'incident_matching_metadata'. (see [below for nested schema](#nestedblock--mark_as_down_metadata_rule))
 - `position` (Number) The position of this resource on your status page, indexed from zero. If you don't specify a position, we add the resource to the end of the status page. When you specify a position of an existing resource, we add the resource to this position and shift resources below to accommodate.
 - `status_page_section_id` (Number) The ID of the Status Page Section. If you don't specify a status_page_section_id, we add the resource to the first section. If there are no sections in the status page yet, one will be automatically created for you.
 - `widget_type` (String) What widget to display for this resource. Expects one of three values: plain - only display status, history - display detailed historical status, response_times - add a response times chart (only for Monitor resource type). This takes preference over history when both parameters are present.
@@ -36,6 +40,70 @@ https://betterstack.com/docs/uptime/api/status-page-resources/
 - `id` (String) The ID of this Status Page Resource.
 - `status` (String) The current status of the resource. Can be one of `not_monitored` (when the underlying monitor is paused), `operational`, `maintenance`, `degraded`, or `downtime`
 - `status_history` (List of Object) History of a single status page resource history (see [below for nested schema](#nestedatt--status_history))
+
+<a id="nestedblock--mark_as_degraded_metadata_rule"></a>
+### Nested Schema for `mark_as_degraded_metadata_rule`
+
+Required:
+
+- `key` (String) The metadata key to match against.
+- `metadata_value` (Block List, Min: 1) List of metadata values that should trigger the degraded status. (see [below for nested schema](#nestedblock--mark_as_degraded_metadata_rule--metadata_value))
+
+<a id="nestedblock--mark_as_degraded_metadata_rule--metadata_value"></a>
+### Nested Schema for `mark_as_degraded_metadata_rule.metadata_value`
+
+Optional:
+
+- `email` (String) Email of the referenced user when type is `User`.
+- `item_id` (String) ID of the referenced item when type is different than `String`.
+- `name` (String) Name of the referenced item when type is different than `String`.
+- `type` (String) Value types can be grouped into 2 main categories:
+  - **Scalar**: `String`
+  - **Reference**: `User`, `Team`, `Policy`, `Schedule`, `SlackIntegration`, `LinearIntegration`, `JiraIntegration`, `MicrosoftTeamsWebhook`, `ZapierWebhook`, `NativeWebhook`, `PagerDutyWebhook`
+  
+  The value of a **Scalar** type is defined using the value field.
+  
+  The value of a **Reference** type is defined using one of the following fields:
+  - `item_id` - great choice when you know the ID of the target item.
+  - `email` - your go-to choice when you're referencing users.
+  - `name` - can be used to reference other items like teams, policies, etc.
+  
+  **The reference types require the presence of at least one of the three fields: `item_id`, `name`, `email`.**
+- `value` (String) Value when type is String.
+
+
+
+<a id="nestedblock--mark_as_down_metadata_rule"></a>
+### Nested Schema for `mark_as_down_metadata_rule`
+
+Required:
+
+- `key` (String) The metadata key to match against.
+- `metadata_value` (Block List, Min: 1) List of metadata values that should trigger the down status. (see [below for nested schema](#nestedblock--mark_as_down_metadata_rule--metadata_value))
+
+<a id="nestedblock--mark_as_down_metadata_rule--metadata_value"></a>
+### Nested Schema for `mark_as_down_metadata_rule.metadata_value`
+
+Optional:
+
+- `email` (String) Email of the referenced user when type is `User`.
+- `item_id` (String) ID of the referenced item when type is different than `String`.
+- `name` (String) Name of the referenced item when type is different than `String`.
+- `type` (String) Value types can be grouped into 2 main categories:
+  - **Scalar**: `String`
+  - **Reference**: `User`, `Team`, `Policy`, `Schedule`, `SlackIntegration`, `LinearIntegration`, `JiraIntegration`, `MicrosoftTeamsWebhook`, `ZapierWebhook`, `NativeWebhook`, `PagerDutyWebhook`
+  
+  The value of a **Scalar** type is defined using the value field.
+  
+  The value of a **Reference** type is defined using one of the following fields:
+  - `item_id` - great choice when you know the ID of the target item.
+  - `email` - your go-to choice when you're referencing users.
+  - `name` - can be used to reference other items like teams, policies, etc.
+  
+  **The reference types require the presence of at least one of the three fields: `item_id`, `name`, `email`.**
+- `value` (String) Value when type is String.
+
+
 
 <a id="nestedatt--status_history"></a>
 ### Nested Schema for `status_history`

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -256,7 +256,7 @@ resource "betteruptime_status_page_resource" "email" {
   # Mark as degraded based on User-type metadata
   mark_as_degraded_for = "incident_matching_metadata"
   mark_as_degraded_metadata_rule {
-    key        = "Assigned User"
+    key = "Assigned User"
     metadata_value {
       type  = "User"
       email = "petr@betterstack.com"
@@ -269,9 +269,9 @@ resource "betteruptime_status_page_resource" "email_api" {
   status_page_section_id = betteruptime_status_page_section.monitors.id
 
   # Link the same resource as in betteruptime_status_page_resource.email, with different rules
-  resource_id            = betteruptime_email_integration.this.id
-  resource_type          = "EmailIntegration"
-  public_name            = "API"
+  resource_id   = betteruptime_email_integration.this.id
+  resource_type = "EmailIntegration"
+  public_name   = "API"
 
   # Mark as down only for incidents matching specific metadata
   mark_as_down_for = "incident_matching_metadata"

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -222,6 +222,18 @@ resource "betteruptime_metadata" "assigned_user" {
   }
 }
 
+resource "betteruptime_metadata" "assigned_policy" {
+  owner_type = "EmailIntegration"
+  owner_id   = betteruptime_email_integration.this.id
+  key        = "Assigned Policy"
+  metadata_value {
+    type    = "Policy"
+    item_id = betteruptime_policy.this.id
+    # Alternatively, you can use name to find the escalation policy:
+    # name = "Low-Priority Escalation Policy"
+  }
+}
+
 resource "betteruptime_status_page_resource" "email" {
   status_page_id         = betteruptime_status_page.this.id
   status_page_section_id = betteruptime_status_page_section.monitors.id

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -22,13 +22,13 @@ resource "betteruptime_status_page" "this" {
   timezone     = "Eastern Time (US & Canada)"
   subdomain    = coalesce(var.betteruptime_status_page_subdomain, random_id.status_page_subdomain.hex)
   subscribable = true
-  ip_allowlist = [
-    "# Office network",
-    "192.168.1.0/24",
-    "# Production servers",
-    "172.16.0.0/16",
-    "2001:0db8:85a3::/64",
-  ]
+  # ip_allowlist = [
+  #   "# Office network",
+  #   "192.168.1.0/24",
+  #   "# Production servers",
+  #   "172.16.0.0/16",
+  #   "2001:0db8:85a3::/64",
+  # ]
 }
 
 resource "betteruptime_status_page_section" "monitors" {
@@ -202,6 +202,65 @@ resource "betteruptime_email_integration" "this" {
     match_type     = "match_between"
     content_before = "Description:"
     content_after  = "\n"
+  }
+  other_started_fields {
+    name           = "Severity"
+    field_target   = "body"
+    match_type     = "match_between"
+    content_before = "Severity:"
+    content_after  = "\n"
+  }
+}
+
+resource "betteruptime_metadata" "assigned_user" {
+  owner_type = "EmailIntegration"
+  owner_id   = betteruptime_email_integration.this.id
+  key        = "Assigned User"
+  metadata_value {
+    type  = "User"
+    email = "petr@betterstack.com"
+  }
+}
+
+resource "betteruptime_status_page_resource" "email" {
+  status_page_id         = betteruptime_status_page.this.id
+  status_page_section_id = betteruptime_status_page_section.monitors.id
+  resource_id            = betteruptime_email_integration.this.id
+  resource_type          = "EmailIntegration"
+  public_name            = "General status"
+
+  # Mark as down only for incidents matching specific metadata
+  mark_as_down_for = "incident_matching_metadata"
+  mark_as_down_metadata_rule {
+    key = "Severity"
+    metadata_value {
+      value = "high"
+    }
+    metadata_value {
+      value = "urgent"
+    }
+  }
+
+  # Mark as degraded for any incident
+  mark_as_degraded_for = "any_incident"
+}
+
+resource "betteruptime_status_page_resource" "email_api" {
+  status_page_id         = betteruptime_status_page.this.id
+  status_page_section_id = betteruptime_status_page_section.monitors.id
+
+  # Link the same resource as in betteruptime_status_page_resource.email, with different rules
+  resource_id            = betteruptime_email_integration.this.id
+  resource_type          = "EmailIntegration"
+  public_name            = "API"
+
+  # Mark as down only for incidents matching specific metadata
+  mark_as_down_for = "incident_matching_metadata"
+  mark_as_down_metadata_rule {
+    key = "Caused by"
+    metadata_value {
+      value = "API"
+    }
   }
 }
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -22,13 +22,13 @@ resource "betteruptime_status_page" "this" {
   timezone     = "Eastern Time (US & Canada)"
   subdomain    = coalesce(var.betteruptime_status_page_subdomain, random_id.status_page_subdomain.hex)
   subscribable = true
-  # ip_allowlist = [
-  #   "# Office network",
-  #   "192.168.1.0/24",
-  #   "# Production servers",
-  #   "172.16.0.0/16",
-  #   "2001:0db8:85a3::/64",
-  # ]
+  ip_allowlist = [
+    "# Office network",
+    "192.168.1.0/24",
+    "# Production servers",
+    "172.16.0.0/16",
+    "2001:0db8:85a3::/64",
+  ]
 }
 
 resource "betteruptime_status_page_section" "monitors" {

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -253,8 +253,15 @@ resource "betteruptime_status_page_resource" "email" {
     }
   }
 
-  # Mark as degraded for any incident
-  mark_as_degraded_for = "any_incident"
+  # Mark as degraded based on User-type metadata
+  mark_as_degraded_for = "incident_matching_metadata"
+  mark_as_degraded_metadata_rule {
+    key        = "Assigned User"
+    metadata_value {
+      type  = "User"
+      email = "petr@betterstack.com"
+    }
+  }
 }
 
 resource "betteruptime_status_page_resource" "email_api" {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.2"
+      version = ">= 0.20.5"
     }
   }
 }

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -358,12 +359,59 @@ func validateMetadata(ctx context.Context, d *schema.ResourceDiff, m interface{}
 		return fmt.Errorf("there cannot be metadata_value defined, when the deprecated field value is used")
 	}
 
+	// Get raw config to check what was actually configured
+	rawConfig := d.GetRawConfig()
+
 	for i, v := range metadataValues {
 		value := v.(map[string]interface{})
-		if err := validateMetadataValue(value, fmt.Sprintf("metadata_value.%d", i)); err != nil {
+		if err := validateMetadataValueWithRawConfig(value, rawConfig.GetAttr("metadata_value").AsValueSlice()[i], fmt.Sprintf("metadata_value.%d", i)); err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+func validateMetadataValueWithRawConfig(attrMap map[string]interface{}, rawConfig cty.Value, path string) error {
+	attrType := attrMap["type"].(string)
+
+	// Validation for String type
+	if attrType == "String" {
+		if value, ok := attrMap["value"].(string); !ok || value == "" {
+			return fmt.Errorf("%s: value must be set for String type", path)
+		}
+		if itemID, ok := attrMap["item_id"].(string); ok && itemID != "" {
+			return fmt.Errorf("%s: item_id must not be set for String type", path)
+		}
+		if email, ok := attrMap["email"].(string); ok && email != "" {
+			return fmt.Errorf("%s: email must not be set for String type", path)
+		}
+		if name, ok := attrMap["name"].(string); ok && name != "" {
+			return fmt.Errorf("%s: name must not be set for String type", path)
+		}
+		return nil
+	}
+
+	// Validation for non-String types
+	if value, ok := attrMap["value"].(string); ok && value != "" {
+		return fmt.Errorf("%s: value must not be set for %s type", path, attrType)
+	}
+
+	// Check if any identifier fields are configured in the raw config
+	hasConfiguredIdentifier := false
+	if rawConfig.GetAttr("item_id").IsNull() == false {
+		hasConfiguredIdentifier = true
+	}
+	if rawConfig.GetAttr("email").IsNull() == false {
+		hasConfiguredIdentifier = true
+	}
+	if rawConfig.GetAttr("name").IsNull() == false {
+		hasConfiguredIdentifier = true
+	}
+
+	if !hasConfiguredIdentifier {
+		return fmt.Errorf("%s: at least one of item_id, email, or name must be set for %s type", path, attrType)
+	}
+
 	return nil
 }
 

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -398,13 +398,13 @@ func validateMetadataValueWithRawConfig(attrMap map[string]interface{}, rawConfi
 
 	// Check if any identifier fields are configured in the raw config
 	hasConfiguredIdentifier := false
-	if rawConfig.GetAttr("item_id").IsNull() == false {
+	if !rawConfig.GetAttr("item_id").IsNull() {
 		hasConfiguredIdentifier = true
 	}
-	if rawConfig.GetAttr("email").IsNull() == false {
+	if !rawConfig.GetAttr("email").IsNull() {
 		hasConfiguredIdentifier = true
 	}
-	if rawConfig.GetAttr("name").IsNull() == false {
+	if !rawConfig.GetAttr("name").IsNull() {
 		hasConfiguredIdentifier = true
 	}
 

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -228,10 +228,9 @@ func loadStatusPageResourceMetadataRule(d *schema.ResourceData, ruleKey string) 
 	return &metadataRule
 }
 
-func statusPageResourceMetadataRuleCopyAttrs(d *schema.ResourceData, rule *map[string]interface{}, ruleKey string) {
+func statusPageResourceMetadataRuleCopyAttrs(d *schema.ResourceData, rule *map[string]interface{}, ruleKey string) error {
 	if rule == nil {
-		d.Set(ruleKey, []interface{}{})
-		return
+		return d.Set(ruleKey, []interface{}{})
 	}
 
 	metadataRule := make(map[string]interface{})
@@ -284,11 +283,11 @@ func statusPageResourceMetadataRuleCopyAttrs(d *schema.ResourceData, rule *map[s
 		metadataRule["metadata_value"] = metadataValues
 	}
 
-	if len(metadataRule) > 0 {
-		d.Set(ruleKey, []interface{}{metadataRule})
-	} else {
-		d.Set(ruleKey, []interface{}{})
+	if len(metadataRule) == 0 {
+		return d.Set(ruleKey, []interface{}{})
 	}
+
+	return d.Set(ruleKey, []interface{}{metadataRule})
 }
 
 func validateStatusPageResource(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
@@ -443,9 +442,13 @@ func statusPageResourceCopyAttrs(d *schema.ResourceData, in *statusPageResource)
 	var derr diag.Diagnostics
 	for _, e := range statusPageResourceRef(in) {
 		if e.k == "mark_as_down_metadata_rule" {
-			statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDownMetadataRule, "mark_as_down_metadata_rule")
+			if err := statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDownMetadataRule, "mark_as_down_metadata_rule"); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		} else if e.k == "mark_as_degraded_metadata_rule" {
-			statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDegradedMetadataRule, "mark_as_degraded_metadata_rule")
+			if err := statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDegradedMetadataRule, "mark_as_degraded_metadata_rule"); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		} else {
 			if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 				derr = append(derr, diag.FromErr(err)[0])

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -97,6 +97,64 @@ var statusPageResourceSchema = map[string]*schema.Schema{
 		Optional:    false,
 		Computed:    true,
 	},
+	"mark_as_down_for": {
+		Description:  "How to mark this resource as down. Can be one of `no_incident`, `any_incident`, or `incident_matching_metadata`.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"no_incident", "any_incident", "incident_matching_metadata"}, false),
+	},
+	"mark_as_down_metadata_rule": {
+		Description: "Metadata rule for marking resource as down. Only applicable when mark_as_down_for is 'incident_matching_metadata'.",
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Description: "The metadata key to match against.",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"metadata_value": {
+					Description: "List of metadata values that should trigger the down status.",
+					Type:        schema.TypeList,
+					Required:    true,
+					MinItems:    1,
+					Elem:        &schema.Resource{Schema: metadataValueSchema},
+				},
+			},
+		},
+	},
+	"mark_as_degraded_for": {
+		Description:  "How to mark this resource as degraded. Can be one of `no_incident`, `any_incident`, or `incident_matching_metadata`.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"no_incident", "any_incident", "incident_matching_metadata"}, false),
+	},
+	"mark_as_degraded_metadata_rule": {
+		Description: "Metadata rule for marking resource as degraded. Only applicable when mark_as_degraded_for is 'incident_matching_metadata'.",
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"key": {
+					Description: "The metadata key to match against.",
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"metadata_value": {
+					Description: "List of metadata values that should trigger the degraded status.",
+					Type:        schema.TypeList,
+					Required:    true,
+					MinItems:    1,
+					Elem:        &schema.Resource{Schema: metadataValueSchema},
+				},
+			},
+		},
+	},
 }
 
 var statusPageStatusHistorySchema = map[string]*schema.Schema{
@@ -126,12 +184,209 @@ var statusPageStatusHistorySchema = map[string]*schema.Schema{
 	},
 }
 
+func validateMetadataRule(v interface{}, k string) (ws []string, errors []error) {
+	ruleList := v.([]interface{})
+	if len(ruleList) == 0 {
+		return
+	}
+
+	rule := ruleList[0].(map[string]interface{})
+
+	// Check if key exists and is not empty
+	if key, ok := rule["key"]; !ok || key.(string) == "" {
+		errors = append(errors, fmt.Errorf("%s: key is required and cannot be empty", k))
+	}
+
+	// Check if metadata_value exists and has at least one item
+	if metadataValues, ok := rule["metadata_value"]; !ok {
+		errors = append(errors, fmt.Errorf("%s: metadata_value is required", k))
+	} else {
+		metadataValueList := metadataValues.([]interface{})
+		if len(metadataValueList) == 0 {
+			errors = append(errors, fmt.Errorf("%s: at least one metadata_value is required", k))
+		}
+
+		// Validate each metadata value
+		for i, value := range metadataValueList {
+			valueMap := value.(map[string]interface{})
+			if itemID, ok := valueMap["item_id"]; !ok || itemID.(string) == "" {
+				errors = append(errors, fmt.Errorf("%s: metadata_value[%d]: item_id is required and cannot be empty", k, i))
+			}
+			// The type field from metadataValueSchema should be present
+			if valueType, ok := valueMap["type"]; !ok || valueType.(string) == "" {
+				errors = append(errors, fmt.Errorf("%s: metadata_value[%d]: type is required and cannot be empty", k, i))
+			}
+		}
+	}
+
+	return
+}
+
+// Helper functions to convert between Terraform schema format and API format for metadata rules
+
+func convertMetadataRuleToAPI(tfRule []interface{}) map[string]interface{} {
+	if len(tfRule) == 0 {
+		return nil
+	}
+
+	rule := tfRule[0].(map[string]interface{})
+	key := rule["key"].(string)
+	metadataValues := rule["metadata_value"].([]interface{})
+
+	apiValues := make([]interface{}, len(metadataValues))
+	for i, v := range metadataValues {
+		valueMap := v.(map[string]interface{})
+		valueType := valueMap["type"].(string)
+
+		if valueType == "String" {
+			// For string values, only send the value field
+			if value, ok := valueMap["value"].(string); ok {
+				apiValues[i] = map[string]interface{}{
+					"value": value,
+				}
+			}
+		} else {
+			// For reference values, send type and one of item_id/name/email
+			apiValue := map[string]interface{}{
+				"type": valueType,
+			}
+
+			if itemID, ok := valueMap["item_id"].(string); ok && itemID != "" {
+				apiValue["item_id"] = itemID
+			}
+			if name, ok := valueMap["name"].(string); ok && name != "" {
+				apiValue["name"] = name
+			}
+			if email, ok := valueMap["email"].(string); ok && email != "" {
+				apiValue["email"] = email
+			}
+
+			apiValues[i] = apiValue
+		}
+	}
+
+	return map[string]interface{}{
+		"key":    key,
+		"values": apiValues,
+	}
+}
+
+func convertMetadataRuleFromAPI(apiRule map[string]interface{}) []interface{} {
+	if apiRule == nil {
+		return nil
+	}
+
+	key, ok := apiRule["key"]
+	if !ok {
+		return nil
+	}
+	keyStr, ok := key.(string)
+	if !ok {
+		return nil
+	}
+
+	values, ok := apiRule["values"]
+	if !ok {
+		return nil
+	}
+	valuesArr, ok := values.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	tfMetadataValues := make([]interface{}, len(valuesArr))
+
+	for i, v := range valuesArr {
+		valueMap, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		tfValue := map[string]interface{}{}
+
+		// Handle type (always present in API response)
+		if itemType, ok := valueMap["type"]; ok {
+			if itemTypeStr, ok := itemType.(string); ok {
+				tfValue["type"] = itemTypeStr
+			}
+		}
+
+		// For string values, handle the value field
+		if value, ok := valueMap["value"]; ok {
+			if valueStr, ok := value.(string); ok {
+				tfValue["value"] = valueStr
+			}
+		}
+
+		// For reference values, handle item_id, name, email
+		if itemID, ok := valueMap["item_id"]; ok {
+			if itemIDStr, ok := itemID.(string); ok {
+				tfValue["item_id"] = itemIDStr
+			}
+		}
+
+		if name, ok := valueMap["name"]; ok {
+			if nameStr, ok := name.(string); ok {
+				tfValue["name"] = nameStr
+			}
+		}
+
+		if email, ok := valueMap["email"]; ok {
+			if emailStr, ok := email.(string); ok {
+				tfValue["email"] = emailStr
+			}
+		}
+
+		tfMetadataValues[i] = tfValue
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"key":            keyStr,
+			"metadata_value": tfMetadataValues,
+		},
+	}
+}
+
+func statusPageResourceCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// Validate mark_as_down_for and mark_as_down_metadata_rule relationship
+	markAsDownFor, hasMarkAsDownFor := d.GetOk("mark_as_down_for")
+	markAsDownMetadataRule := d.Get("mark_as_down_metadata_rule").([]interface{})
+
+	if hasMarkAsDownFor && markAsDownFor.(string) == "incident_matching_metadata" {
+		if len(markAsDownMetadataRule) == 0 {
+			return fmt.Errorf("mark_as_down_metadata_rule is required when mark_as_down_for is 'incident_matching_metadata'")
+		}
+	} else if hasMarkAsDownFor && markAsDownFor.(string) != "incident_matching_metadata" {
+		if len(markAsDownMetadataRule) > 0 {
+			return fmt.Errorf("mark_as_down_metadata_rule can only be used when mark_as_down_for is 'incident_matching_metadata'")
+		}
+	}
+
+	// Validate mark_as_degraded_for and mark_as_degraded_metadata_rule relationship
+	markAsDegradedFor, hasMarkAsDegradedFor := d.GetOk("mark_as_degraded_for")
+	markAsDegradedMetadataRule := d.Get("mark_as_degraded_metadata_rule").([]interface{})
+
+	if hasMarkAsDegradedFor && markAsDegradedFor.(string) == "incident_matching_metadata" {
+		if len(markAsDegradedMetadataRule) == 0 {
+			return fmt.Errorf("mark_as_degraded_metadata_rule is required when mark_as_degraded_for is 'incident_matching_metadata'")
+		}
+	} else if hasMarkAsDegradedFor && markAsDegradedFor.(string) != "incident_matching_metadata" {
+		if len(markAsDegradedMetadataRule) > 0 {
+			return fmt.Errorf("mark_as_degraded_metadata_rule can only be used when mark_as_degraded_for is 'incident_matching_metadata'")
+		}
+	}
+
+	return nil
+}
+
 func newStatusPageResourceResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: statusPageResourceCreate,
 		ReadContext:   statusPageResourceRead,
 		UpdateContext: statusPageResourceUpdate,
 		DeleteContext: statusPageResourceDelete,
+		CustomizeDiff: statusPageResourceCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				split := strings.SplitN(d.Id(), "/", 2)
@@ -151,18 +406,22 @@ func newStatusPageResourceResource() *schema.Resource {
 }
 
 type statusPageResource struct {
-	StatusPageSectionID *int                      `json:"status_page_section_id,omitempty"`
-	ResourceID          *int                      `json:"resource_id,omitempty"`
-	ResourceType        *string                   `json:"resource_type,omitempty"`
-	PublicName          *string                   `json:"public_name,omitempty"`
-	Explanation         *string                   `json:"explanation,omitempty"`
-	History             *bool                     `json:"history,omitempty"`
-	Position            *int                      `json:"position,omitempty"`
-	FixedPosition       *bool                     `json:"fixed_position,omitempty"`
-	WidgetType          *string                   `json:"widget_type,omitempty"`
-	Availability        *float32                  `json:"availability,omitempty"`
-	Status              *string                   `json:"status,omitempty"`
-	StatusHistory       *[]map[string]interface{} `json:"status_history,omitempty"`
+	StatusPageSectionID        *int                      `json:"status_page_section_id,omitempty"`
+	ResourceID                 *int                      `json:"resource_id,omitempty"`
+	ResourceType               *string                   `json:"resource_type,omitempty"`
+	PublicName                 *string                   `json:"public_name,omitempty"`
+	Explanation                *string                   `json:"explanation,omitempty"`
+	History                    *bool                     `json:"history,omitempty"`
+	Position                   *int                      `json:"position,omitempty"`
+	FixedPosition              *bool                     `json:"fixed_position,omitempty"`
+	WidgetType                 *string                   `json:"widget_type,omitempty"`
+	Availability               *float32                  `json:"availability,omitempty"`
+	Status                     *string                   `json:"status,omitempty"`
+	StatusHistory              *[]map[string]interface{} `json:"status_history,omitempty"`
+	MarkAsDownFor              *string                   `json:"mark_as_down_for,omitempty"`
+	MarkAsDownMetadataRule     *map[string]interface{}   `json:"mark_as_down_metadata_rule,omitempty"`
+	MarkAsDegradedFor          *string                   `json:"mark_as_degraded_for,omitempty"`
+	MarkAsDegradedMetadataRule *map[string]interface{}   `json:"mark_as_degraded_metadata_rule,omitempty"`
 }
 
 type statusPageResourceHTTPResponse struct {
@@ -192,6 +451,10 @@ func statusPageResourceRef(in *statusPageResource) []struct {
 		{k: "availability", v: &in.Availability},
 		{k: "status_history", v: &in.StatusHistory},
 		{k: "status", v: &in.Status},
+		{k: "mark_as_down_for", v: &in.MarkAsDownFor},
+		{k: "mark_as_down_metadata_rule", v: &in.MarkAsDownMetadataRule},
+		{k: "mark_as_degraded_for", v: &in.MarkAsDegradedFor},
+		{k: "mark_as_degraded_metadata_rule", v: &in.MarkAsDegradedMetadataRule},
 	}
 }
 
@@ -200,7 +463,19 @@ func statusPageResourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	for _, e := range statusPageResourceRef(&in) {
 		// Skip loading status history when preparing to send the request
 		if e.k != "status_history" {
-			load(d, e.k, e.v)
+			if e.k == "mark_as_down_metadata_rule" {
+				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
+					apiRule := convertMetadataRuleToAPI(tfRule)
+					in.MarkAsDownMetadataRule = &apiRule
+				}
+			} else if e.k == "mark_as_degraded_metadata_rule" {
+				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
+					apiRule := convertMetadataRuleToAPI(tfRule)
+					in.MarkAsDegradedMetadataRule = &apiRule
+				}
+			} else {
+				load(d, e.k, e.v)
+			}
 		}
 	}
 	in.FixedPosition = truePtr()
@@ -228,8 +503,28 @@ func statusPageResourceRead(ctx context.Context, d *schema.ResourceData, meta in
 func statusPageResourceCopyAttrs(d *schema.ResourceData, in *statusPageResource) diag.Diagnostics {
 	var derr diag.Diagnostics
 	for _, e := range statusPageResourceRef(in) {
-		if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
-			derr = append(derr, diag.FromErr(err)[0])
+		if e.k == "mark_as_down_metadata_rule" {
+			if in.MarkAsDownMetadataRule != nil && *in.MarkAsDownMetadataRule != nil {
+				tfRule := convertMetadataRuleFromAPI(*in.MarkAsDownMetadataRule)
+				if tfRule != nil {
+					if err := d.Set(e.k, tfRule); err != nil {
+						derr = append(derr, diag.FromErr(err)[0])
+					}
+				}
+			}
+		} else if e.k == "mark_as_degraded_metadata_rule" {
+			if in.MarkAsDegradedMetadataRule != nil && *in.MarkAsDegradedMetadataRule != nil {
+				tfRule := convertMetadataRuleFromAPI(*in.MarkAsDegradedMetadataRule)
+				if tfRule != nil {
+					if err := d.Set(e.k, tfRule); err != nil {
+						derr = append(derr, diag.FromErr(err)[0])
+					}
+				}
+			}
+		} else {
+			if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
+				derr = append(derr, diag.FromErr(err)[0])
+			}
 		}
 	}
 	return derr
@@ -240,13 +535,25 @@ func statusPageResourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	var out policyHTTPResponse
 	for _, e := range statusPageResourceRef(&in) {
 		if d.HasChange(e.k) {
-			load(d, e.k, e.v)
-			// When updating resource ID, we need to update resource type as well (and vice-versa)
-			if e.k == "resource_id" {
-				load(d, "resource_type", &in.ResourceType)
-			}
-			if e.k == "resource_type" {
-				load(d, "resource_id", &in.ResourceID)
+			if e.k == "mark_as_down_metadata_rule" {
+				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
+					apiRule := convertMetadataRuleToAPI(tfRule)
+					in.MarkAsDownMetadataRule = &apiRule
+				}
+			} else if e.k == "mark_as_degraded_metadata_rule" {
+				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
+					apiRule := convertMetadataRuleToAPI(tfRule)
+					in.MarkAsDegradedMetadataRule = &apiRule
+				}
+			} else {
+				load(d, e.k, e.v)
+				// When updating resource ID, we need to update resource type as well (and vice-versa)
+				if e.k == "resource_id" {
+					load(d, "resource_type", &in.ResourceType)
+				}
+				if e.k == "resource_type" {
+					load(d, "resource_id", &in.ResourceID)
+				}
 			}
 		}
 	}

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -184,196 +185,142 @@ var statusPageStatusHistorySchema = map[string]*schema.Schema{
 	},
 }
 
-func validateMetadataRule(v interface{}, k string) (ws []string, errors []error) {
-	ruleList := v.([]interface{})
-	if len(ruleList) == 0 {
+func loadStatusPageResourceMetadataRule(d *schema.ResourceData, ruleKey string) *map[string]interface{} {
+	metadataRules := d.Get(ruleKey).([]interface{})
+	if len(metadataRules) == 0 {
+		return nil
+	}
+
+	rule := metadataRules[0].(map[string]interface{})
+	metadataRule := make(map[string]interface{})
+
+	if key, ok := rule["key"].(string); ok && key != "" {
+		metadataRule["key"] = key
+	}
+
+	if metadataValues, ok := rule["metadata_value"].([]interface{}); ok && len(metadataValues) > 0 {
+		values := make([]metadataValue, 0, len(metadataValues))
+		for _, v := range metadataValues {
+			valueMap := v.(map[string]interface{})
+			value := metadataValue{}
+
+			if v, ok := valueMap["type"].(string); ok && v != "" {
+				value.Type = v
+			}
+			if v, ok := valueMap["value"].(string); ok && v != "" {
+				value.Value = &v
+			}
+			if v, ok := valueMap["item_id"].(string); ok && v != "" {
+				value.ItemID = json.Number(v)
+			}
+			if v, ok := valueMap["email"].(string); ok && v != "" {
+				value.Email = &v
+			}
+			if v, ok := valueMap["name"].(string); ok && v != "" {
+				value.Name = &v
+			}
+
+			values = append(values, value)
+		}
+		metadataRule["values"] = values
+	}
+
+	return &metadataRule
+}
+
+func statusPageResourceMetadataRuleCopyAttrs(d *schema.ResourceData, rule *map[string]interface{}, ruleKey string) {
+	if rule == nil {
+		d.Set(ruleKey, []interface{}{})
 		return
 	}
 
-	rule := ruleList[0].(map[string]interface{})
+	metadataRule := make(map[string]interface{})
 
-	// Check if key exists and is not empty
-	if key, ok := rule["key"]; !ok || key.(string) == "" {
-		errors = append(errors, fmt.Errorf("%s: key is required and cannot be empty", k))
+	if key, ok := (*rule)["key"].(string); ok {
+		metadataRule["key"] = key
 	}
 
-	// Check if metadata_value exists and has at least one item
-	if metadataValues, ok := rule["metadata_value"]; !ok {
-		errors = append(errors, fmt.Errorf("%s: metadata_value is required", k))
-	} else {
-		metadataValueList := metadataValues.([]interface{})
-		if len(metadataValueList) == 0 {
-			errors = append(errors, fmt.Errorf("%s: at least one metadata_value is required", k))
-		}
-
-		// Validate each metadata value
-		for i, value := range metadataValueList {
-			valueMap := value.(map[string]interface{})
-			if itemID, ok := valueMap["item_id"]; !ok || itemID.(string) == "" {
-				errors = append(errors, fmt.Errorf("%s: metadata_value[%d]: item_id is required and cannot be empty", k, i))
+	if values, ok := (*rule)["values"].([]interface{}); ok && len(values) > 0 {
+		metadataValues := make([]interface{}, 0, len(values))
+		for i, v := range values {
+			valueMap, ok := v.(map[string]interface{})
+			if !ok {
+				continue
 			}
-			// The type field from metadataValueSchema should be present
-			if valueType, ok := valueMap["type"]; !ok || valueType.(string) == "" {
-				errors = append(errors, fmt.Errorf("%s: metadata_value[%d]: type is required and cannot be empty", k, i))
+			metadataValue := make(map[string]interface{})
+
+			if valueType, ok := valueMap["type"].(string); ok {
+				metadataValue["type"] = valueType
 			}
-		}
-	}
-
-	return
-}
-
-// Helper functions to convert between Terraform schema format and API format for metadata rules
-
-func convertMetadataRuleToAPI(tfRule []interface{}) map[string]interface{} {
-	if len(tfRule) == 0 {
-		return nil
-	}
-
-	rule := tfRule[0].(map[string]interface{})
-	key := rule["key"].(string)
-	metadataValues := rule["metadata_value"].([]interface{})
-
-	apiValues := make([]interface{}, len(metadataValues))
-	for i, v := range metadataValues {
-		valueMap := v.(map[string]interface{})
-		valueType := valueMap["type"].(string)
-
-		if valueType == "String" {
-			// For string values, only send the value field
 			if value, ok := valueMap["value"].(string); ok {
-				apiValues[i] = map[string]interface{}{
-					"value": value,
+				metadataValue["value"] = value
+			}
+
+			// Only include item_id, email, name if they were configured in Terraform
+			configPrefix := fmt.Sprintf("%s.0.metadata_value.%d", ruleKey, i)
+			if _, ok := d.GetOk(configPrefix + ".item_id"); ok {
+				if id, ok := valueMap["item_id"]; ok && id != nil {
+					switch typedId := id.(type) {
+					case json.Number:
+						metadataValue["item_id"] = typedId.String()
+					case float64:
+						metadataValue["item_id"] = fmt.Sprintf("%.0f", typedId)
+					}
 				}
 			}
-		} else {
-			// For reference values, send type and one of item_id/name/email
-			apiValue := map[string]interface{}{
-				"type": valueType,
+			if _, ok := d.GetOk(configPrefix + ".email"); ok {
+				if email, ok := valueMap["email"].(string); ok {
+					metadataValue["email"] = email
+				}
+			}
+			if _, ok := d.GetOk(configPrefix + ".name"); ok {
+				if name, ok := valueMap["name"].(string); ok {
+					metadataValue["name"] = name
+				}
 			}
 
-			if itemID, ok := valueMap["item_id"].(string); ok && itemID != "" {
-				apiValue["item_id"] = itemID
-			}
-			if name, ok := valueMap["name"].(string); ok && name != "" {
-				apiValue["name"] = name
-			}
-			if email, ok := valueMap["email"].(string); ok && email != "" {
-				apiValue["email"] = email
-			}
-
-			apiValues[i] = apiValue
+			metadataValues = append(metadataValues, metadataValue)
 		}
+		metadataRule["metadata_value"] = metadataValues
 	}
 
-	return map[string]interface{}{
-		"key":    key,
-		"values": apiValues,
+	if len(metadataRule) > 0 {
+		d.Set(ruleKey, []interface{}{metadataRule})
+	} else {
+		d.Set(ruleKey, []interface{}{})
 	}
 }
 
-func convertMetadataRuleFromAPI(apiRule map[string]interface{}) []interface{} {
-	if apiRule == nil {
-		return nil
-	}
+func validateStatusPageResource(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	degradedRuleError := validateMetadataRule(d, "mark_as_degraded_for", "mark_as_degraded_metadata_rule")
+	downRuleError := validateMetadataRule(d, "mark_as_down_for", "mark_as_down_metadata_rule")
 
-	key, ok := apiRule["key"]
-	if !ok {
-		return nil
-	}
-	keyStr, ok := key.(string)
-	if !ok {
-		return nil
-	}
-
-	values, ok := apiRule["values"]
-	if !ok {
-		return nil
-	}
-	valuesArr, ok := values.([]interface{})
-	if !ok {
-		return nil
-	}
-
-	tfMetadataValues := make([]interface{}, len(valuesArr))
-
-	for i, v := range valuesArr {
-		valueMap, ok := v.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		tfValue := map[string]interface{}{}
-
-		// Handle type (always present in API response)
-		if itemType, ok := valueMap["type"]; ok {
-			if itemTypeStr, ok := itemType.(string); ok {
-				tfValue["type"] = itemTypeStr
-			}
-		}
-
-		// For string values, handle the value field
-		if value, ok := valueMap["value"]; ok {
-			if valueStr, ok := value.(string); ok {
-				tfValue["value"] = valueStr
-			}
-		}
-
-		// For reference values, handle item_id, name, email
-		if itemID, ok := valueMap["item_id"]; ok {
-			if itemIDStr, ok := itemID.(string); ok {
-				tfValue["item_id"] = itemIDStr
-			}
-		}
-
-		if name, ok := valueMap["name"]; ok {
-			if nameStr, ok := name.(string); ok {
-				tfValue["name"] = nameStr
-			}
-		}
-
-		if email, ok := valueMap["email"]; ok {
-			if emailStr, ok := email.(string); ok {
-				tfValue["email"] = emailStr
-			}
-		}
-
-		tfMetadataValues[i] = tfValue
-	}
-
-	return []interface{}{
-		map[string]interface{}{
-			"key":            keyStr,
-			"metadata_value": tfMetadataValues,
-		},
-	}
+	return errors.Join(degradedRuleError, downRuleError)
 }
 
-func statusPageResourceCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// Validate mark_as_down_for and mark_as_down_metadata_rule relationship
-	markAsDownFor, hasMarkAsDownFor := d.GetOk("mark_as_down_for")
-	markAsDownMetadataRule := d.Get("mark_as_down_metadata_rule").([]interface{})
-
-	if hasMarkAsDownFor && markAsDownFor.(string) == "incident_matching_metadata" {
-		if len(markAsDownMetadataRule) == 0 {
-			return fmt.Errorf("mark_as_down_metadata_rule is required when mark_as_down_for is 'incident_matching_metadata'")
-		}
-	} else if hasMarkAsDownFor && markAsDownFor.(string) != "incident_matching_metadata" {
-		if len(markAsDownMetadataRule) > 0 {
-			return fmt.Errorf("mark_as_down_metadata_rule can only be used when mark_as_down_for is 'incident_matching_metadata'")
-		}
-	}
-
+func validateMetadataRule(d *schema.ResourceDiff, keyFor string, keyMetadataRule string) error {
 	// Validate mark_as_degraded_for and mark_as_degraded_metadata_rule relationship
-	markAsDegradedFor, hasMarkAsDegradedFor := d.GetOk("mark_as_degraded_for")
-	markAsDegradedMetadataRule := d.Get("mark_as_degraded_metadata_rule").([]interface{})
+	markFor, hasMarkFor := d.GetOk(keyFor)
+	metadataRule := d.Get(keyMetadataRule).([]interface{})
 
-	if hasMarkAsDegradedFor && markAsDegradedFor.(string) == "incident_matching_metadata" {
-		if len(markAsDegradedMetadataRule) == 0 {
-			return fmt.Errorf("mark_as_degraded_metadata_rule is required when mark_as_degraded_for is 'incident_matching_metadata'")
+	if hasMarkFor && markFor.(string) == "incident_matching_metadata" {
+		if len(metadataRule) == 0 {
+			return fmt.Errorf("%s is required when %s is 'incident_matching_metadata'", keyMetadataRule, keyFor)
 		}
-	} else if hasMarkAsDegradedFor && markAsDegradedFor.(string) != "incident_matching_metadata" {
-		if len(markAsDegradedMetadataRule) > 0 {
-			return fmt.Errorf("mark_as_degraded_metadata_rule can only be used when mark_as_degraded_for is 'incident_matching_metadata'")
+		// Validate metadata rule structure
+		if len(metadataRule) > 0 {
+			rule := metadataRule[0].(map[string]interface{})
+			metadataValues := rule["metadata_value"].([]interface{})
+			for i, v := range metadataValues {
+				value := v.(map[string]interface{})
+				if err := validateMetadataValue(value, fmt.Sprintf("%s.metadata_value.%d", keyMetadataRule, i)); err != nil {
+					return err
+				}
+			}
+		}
+	} else if hasMarkFor && markFor.(string) != "incident_matching_metadata" {
+		if len(metadataRule) > 0 {
+			return fmt.Errorf("%s can only be used when %s is 'incident_matching_metadata'", keyMetadataRule, keyFor)
 		}
 	}
 
@@ -386,7 +333,7 @@ func newStatusPageResourceResource() *schema.Resource {
 		ReadContext:   statusPageResourceRead,
 		UpdateContext: statusPageResourceUpdate,
 		DeleteContext: statusPageResourceDelete,
-		CustomizeDiff: statusPageResourceCustomizeDiff,
+		CustomizeDiff: validateStatusPageResource,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				split := strings.SplitN(d.Id(), "/", 2)
@@ -435,7 +382,6 @@ func statusPageResourceRef(in *statusPageResource) []struct {
 	k string
 	v interface{}
 } {
-	// TODO:  if reflect.TypeOf(in).NumField() != len([]struct)
 	return []struct {
 		k string
 		v interface{}
@@ -461,21 +407,14 @@ func statusPageResourceRef(in *statusPageResource) []struct {
 func statusPageResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var in statusPageResource
 	for _, e := range statusPageResourceRef(&in) {
-		// Skip loading status history when preparing to send the request
-		if e.k != "status_history" {
-			if e.k == "mark_as_down_metadata_rule" {
-				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
-					apiRule := convertMetadataRuleToAPI(tfRule)
-					in.MarkAsDownMetadataRule = &apiRule
-				}
-			} else if e.k == "mark_as_degraded_metadata_rule" {
-				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
-					apiRule := convertMetadataRuleToAPI(tfRule)
-					in.MarkAsDegradedMetadataRule = &apiRule
-				}
-			} else {
-				load(d, e.k, e.v)
-			}
+		if e.k == "status_history" {
+			// Skip loading status history when preparing to send the request
+		} else if e.k == "mark_as_down_metadata_rule" {
+			in.MarkAsDownMetadataRule = loadStatusPageResourceMetadataRule(d, "mark_as_down_metadata_rule")
+		} else if e.k == "mark_as_degraded_metadata_rule" {
+			in.MarkAsDegradedMetadataRule = loadStatusPageResourceMetadataRule(d, "mark_as_degraded_metadata_rule")
+		} else {
+			load(d, e.k, e.v)
 		}
 	}
 	in.FixedPosition = truePtr()
@@ -504,23 +443,9 @@ func statusPageResourceCopyAttrs(d *schema.ResourceData, in *statusPageResource)
 	var derr diag.Diagnostics
 	for _, e := range statusPageResourceRef(in) {
 		if e.k == "mark_as_down_metadata_rule" {
-			if in.MarkAsDownMetadataRule != nil && *in.MarkAsDownMetadataRule != nil {
-				tfRule := convertMetadataRuleFromAPI(*in.MarkAsDownMetadataRule)
-				if tfRule != nil {
-					if err := d.Set(e.k, tfRule); err != nil {
-						derr = append(derr, diag.FromErr(err)[0])
-					}
-				}
-			}
+			statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDownMetadataRule, "mark_as_down_metadata_rule")
 		} else if e.k == "mark_as_degraded_metadata_rule" {
-			if in.MarkAsDegradedMetadataRule != nil && *in.MarkAsDegradedMetadataRule != nil {
-				tfRule := convertMetadataRuleFromAPI(*in.MarkAsDegradedMetadataRule)
-				if tfRule != nil {
-					if err := d.Set(e.k, tfRule); err != nil {
-						derr = append(derr, diag.FromErr(err)[0])
-					}
-				}
-			}
+			statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDegradedMetadataRule, "mark_as_degraded_metadata_rule")
 		} else {
 			if err := d.Set(e.k, reflect.Indirect(reflect.ValueOf(e.v)).Interface()); err != nil {
 				derr = append(derr, diag.FromErr(err)[0])
@@ -536,15 +461,9 @@ func statusPageResourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	for _, e := range statusPageResourceRef(&in) {
 		if d.HasChange(e.k) {
 			if e.k == "mark_as_down_metadata_rule" {
-				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
-					apiRule := convertMetadataRuleToAPI(tfRule)
-					in.MarkAsDownMetadataRule = &apiRule
-				}
+				in.MarkAsDownMetadataRule = loadStatusPageResourceMetadataRule(d, "mark_as_down_metadata_rule")
 			} else if e.k == "mark_as_degraded_metadata_rule" {
-				if tfRule := d.Get(e.k).([]interface{}); len(tfRule) > 0 {
-					apiRule := convertMetadataRuleToAPI(tfRule)
-					in.MarkAsDegradedMetadataRule = &apiRule
-				}
+				in.MarkAsDegradedMetadataRule = loadStatusPageResourceMetadataRule(d, "mark_as_degraded_metadata_rule")
 			} else {
 				load(d, e.k, e.v)
 				// When updating resource ID, we need to update resource type as well (and vice-versa)

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -455,6 +455,19 @@ func statusPageResourceCopyAttrs(d *schema.ResourceData, in *statusPageResource)
 			}
 		}
 	}
+
+	// Clear metadata rules if they are not active, they would be missing in the API request
+	if d.Get("mark_as_down_for").(string) != "incident_matching_metadata" {
+		if err := d.Set("mark_as_down_metadata_rule", []interface{}{}); err != nil {
+			derr = append(derr, diag.FromErr(err)[0])
+		}
+	}
+	if d.Get("mark_as_degraded_for").(string) != "incident_matching_metadata" {
+		if err := d.Set("mark_as_degraded_metadata_rule", []interface{}{}); err != nil {
+			derr = append(derr, diag.FromErr(err)[0])
+		}
+	}
+
 	return derr
 }
 

--- a/internal/provider/resource_status_page_resource_test.go
+++ b/internal/provider/resource_status_page_resource_test.go
@@ -150,7 +150,7 @@ func TestResourceStatusPageResource(t *testing.T) {
 				ResourceName:      "betteruptime_status_page_resource.this",
 				ImportState:       true,
 				ImportStateId:     "0/1",
-				ImportStateVerify: true,
+				ImportStateVerify: false,
 				PreConfig: func() {
 					t.Log("step 5")
 				},

--- a/internal/provider/resource_status_page_resource_test.go
+++ b/internal/provider/resource_status_page_resource_test.go
@@ -70,7 +70,7 @@ func TestResourceStatusPageResource(t *testing.T) {
 					t.Log("step 2")
 				},
 			},
-			// Step 3 - make no changes, check plan is empty.
+			// Step 3 - update with metadata rules.
 			{
 				Config: fmt.Sprintf(`
 				provider "betteruptime" {
@@ -82,21 +82,77 @@ func TestResourceStatusPageResource(t *testing.T) {
 					resource_id    = "3"
 					resource_type  = "Monitor"
 					public_name    = "%s"
+					mark_as_down_for = "incident_matching_metadata"
+					mark_as_down_metadata_rule {
+						key = "Default escalation policy"
+						metadata_value {
+							type = "Policy"
+							item_id = "102683"
+						}
+						metadata_value {
+							type = "Policy"
+							item_id = "89964"
+						}
+					}
+					mark_as_degraded_for = "any_incident"
 				}
 				`, name),
-				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_status_page_resource.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "public_name", name),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "resource_id", "3"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_for", "incident_matching_metadata"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.key", "Default escalation policy"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.metadata_value.0.type", "Policy"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.metadata_value.0.item_id", "102683"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.metadata_value.1.type", "Policy"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.metadata_value.1.item_id", "89964"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_degraded_for", "any_incident"),
+				),
 				PreConfig: func() {
 					t.Log("step 3")
 				},
 			},
-			// Step 4 - destroy.
+			// Step 4 - make no changes, check plan is empty.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page_resource" "this" {
+					status_page_id = "0"
+					resource_id    = "3"
+					resource_type  = "Monitor"
+					public_name    = "%s"
+					mark_as_down_for = "incident_matching_metadata"
+					mark_as_down_metadata_rule {
+						key = "Default escalation policy"
+						metadata_value {
+							type = "Policy"
+							item_id = "102683"
+						}
+						metadata_value {
+							type = "Policy"
+							item_id = "89964"
+						}
+					}
+					mark_as_degraded_for = "any_incident"
+				}
+				`, name),
+				PlanOnly: true,
+				PreConfig: func() {
+					t.Log("step 4")
+				},
+			},
+			// Step 5 - destroy.
 			{
 				ResourceName:      "betteruptime_status_page_resource.this",
 				ImportState:       true,
 				ImportStateId:     "0/1",
 				ImportStateVerify: true,
 				PreConfig: func() {
-					t.Log("step 4")
+					t.Log("step 5")
 				},
 			},
 		},

--- a/internal/provider/resource_status_page_resource_test.go
+++ b/internal/provider/resource_status_page_resource_test.go
@@ -108,6 +108,7 @@ func TestResourceStatusPageResource(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.metadata_value.1.type", "Policy"),
 					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.0.metadata_value.1.item_id", "89964"),
 					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_degraded_for", "any_incident"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_degraded_metadata_rule.#", "0"),
 				),
 				PreConfig: func() {
 					t.Log("step 3")
@@ -145,14 +146,40 @@ func TestResourceStatusPageResource(t *testing.T) {
 					t.Log("step 4")
 				},
 			},
-			// Step 5 - destroy.
+			// Step 5 - remove metadata
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page_resource" "this" {
+					status_page_id = "0"
+					resource_id    = "3"
+					resource_type  = "Monitor"
+					public_name    = "%s"
+					mark_as_down_for = "any_incident"
+					mark_as_degraded_for = "no_incident"
+				}
+				`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_for", "any_incident"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_down_metadata_rule.#", "0"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_degraded_for", "no_incident"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "mark_as_degraded_metadata_rule.#", "0"),
+				),
+				PreConfig: func() {
+					t.Log("step 3")
+				},
+			},
+			// Step 6 - destroy.
 			{
 				ResourceName:      "betteruptime_status_page_resource.this",
 				ImportState:       true,
 				ImportStateId:     "0/1",
-				ImportStateVerify: false,
+				ImportStateVerify: true,
 				PreConfig: func() {
-					t.Log("step 5")
+					t.Log("step 6")
 				},
 			},
 		},


### PR DESCRIPTION
Allows configuring Advanced setting of Status page resources - i.e. down / degraded rules with metadata filters.

```
resource "betteruptime_status_page_resource" "email" {
  status_page_id         = betteruptime_status_page.this.id
  status_page_section_id = betteruptime_status_page_section.monitors.id
  resource_id            = betteruptime_email_integration.this.id
  resource_type          = "EmailIntegration"
  public_name            = "General status"

  # Mark as down only for incidents matching specific metadata
  mark_as_down_for = "incident_matching_metadata"
  mark_as_down_metadata_rule {
    key = "Severity"
    metadata_value {
      value = "high"
    }
    metadata_value {
      value = "urgent"
    }
  }

  # Mark as degraded based on User-type metadata
  mark_as_degraded_for = "incident_matching_metadata"
  mark_as_degraded_metadata_rule {
    key = "Assigned User"
    metadata_value {
      type  = "User"
      email = "petr@betterstack.com"
    }
  }
}
```

Consistent with how metadata are used in the rest of the provider.

Resolves https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/173