### PR TITLE
Do not fail on monitor validation for unknown fields

### DIFF
--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -695,21 +695,23 @@ func validateMonitor(ctx context.Context, diff *schema.ResourceDiff, v interface
 	}
 
 	// Validate URL requirement based on monitor type
+	monitorUrlIsKnown := diff.NewValueKnown("url")
 	monitorUrl := diff.Get("url").(string)
+	scenarioNameIsKnown := diff.NewValueKnown("scenario_name")
 	scenarioName := diff.Get("scenario_name").(string)
 	monitorType := diff.Get("monitor_type").(string)
 	if monitorType == "playwright" {
-		if monitorUrl == "" && scenarioName == "" {
+		if (monitorUrlIsKnown && monitorUrl == "") && (scenarioNameIsKnown && scenarioName == "") {
 			return fmt.Errorf("'scenario_name' (alternatively, you can use 'url') is required for monitor type '%s'", monitorType)
 		}
 		if monitorUrl != "" && scenarioName != "" && monitorUrl != scenarioName {
 			return fmt.Errorf("when both 'url' and 'scenario_name' are set, they must be equal (got url=%q, scenario_name=%q)", monitorUrl, scenarioName)
 		}
 	} else {
-		if monitorUrl == "" {
+		if monitorUrlIsKnown && monitorUrl == "" {
 			return fmt.Errorf("'url' is required for monitor type '%s'", monitorType)
 		}
-		if scenarioName != "" {
+		if scenarioNameIsKnown && scenarioName != "" {
 			return fmt.Errorf("'scenario_name' can only be set for monitor type 'playwright', not '%s'", monitorType)
 		}
 	}


### PR DESCRIPTION
When `url` or `scenario_name` is a computed value (e.g., an output from another resource), Terraform represents it as unknown during plan, and `diff.Get()` returns an empty string. The validation logic was treating this as "the user left the field empty," incorrectly raising an error.

Guard each check with `diff.NewValueKnown()` so we only validate values that are actually resolved, consistent with the existing pattern in `validateRequestHeader`.

I run into this issue when trying to modify my terraform setup in order to created and attach a reserved IP for one of my VM, the subsequent calls to `terraform plan` fail. I can confirm this patch unlocked me.