### PR TITLE
[U-8016] Bug: [status pages][structure] manually tracked item

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.7
+VERSION := 0.20.10
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_status_page_resource.md
+++ b/docs/resources/betteruptime_status_page_resource.md
@@ -18,8 +18,7 @@ https://betterstack.com/docs/uptime/api/status-page-resources/
 ### Required
 
 - `public_name` (String) The resource name displayed publicly on your status page.
-- `resource_id` (Number) The ID of the resource you are adding.
-- `resource_type` (String) The type of the resource you are adding. Available values: Monitor, MonitorGroup, Heartbeat, HeartbeatGroup, WebhookIntegration, EmailIntegration, IncomingWebhook, ResourceGroup, LogsChart, CatalogReference.
+- `resource_type` (String) The type of the resource you are adding. Available values: ManuallyTrackedItem, Monitor, MonitorGroup, Heartbeat, HeartbeatGroup, WebhookIntegration, EmailIntegration, IncomingWebhook, ResourceGroup, LogsChart, CatalogReference.
 - `status_page_id` (String) The ID of the Status Page.
 
 ### Optional
@@ -31,6 +30,7 @@ https://betterstack.com/docs/uptime/api/status-page-resources/
 - `mark_as_down_for` (String) How to mark this resource as down. Can be one of `no_incident`, `any_incident`, or `incident_matching_metadata`.
 - `mark_as_down_metadata_rule` (Block List, Max: 1) Metadata rule for marking resource as down. Only applicable when mark_as_down_for is 'incident_matching_metadata'. (see [below for nested schema](#nestedblock--mark_as_down_metadata_rule))
 - `position` (Number) The position of this resource on your status page, indexed from zero. If you don't specify a position, we add the resource to the end of the status page. When you specify a position of an existing resource, we add the resource to this position and shift resources below to accommodate.
+- `resource_id` (Number) The ID of the resource you are adding. Omit when resource_type is ManuallyTrackedItem.
 - `status_page_section_id` (Number) The ID of the Status Page Section. If you don't specify a status_page_section_id, we add the resource to the first section. If there are no sections in the status page yet, one will be automatically created for you.
 - `widget_type` (String) What widget to display for this resource. Available values: plain - only display status, history - display historical status, intraday_history - display detailed historical status, response_times - add a response times chart (only for Monitor resource type). This takes preference over history when both parameters are present.
 

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -1,6 +1,6 @@
 This directory contains a sample Terraform configuration for a status page with
-a monitor and a heartbeat. The monitor and the heartbeat are placed into dedicated
-groups and two different status page sections.
+a monitor, a heartbeat and a manually tracked item. These are placed into dedicated
+groups and three different status page sections.
 
 ## Usage
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -47,6 +47,12 @@ resource "betteruptime_status_page_section" "heartbeats" {
   position       = 1
 }
 
+resource "betteruptime_status_page_section" "manually_tracked_items" {
+  status_page_id = betteruptime_status_page.this.id
+  name           = "Manually tracked items"
+  position       = 2
+}
+
 resource "betteruptime_monitor_group" "this" {
   name       = "example"
   sort_index = 0
@@ -138,6 +144,13 @@ resource "betteruptime_status_page_resource" "heartbeat" {
   resource_id            = betteruptime_heartbeat.this.id
   resource_type          = "Heartbeat"
   public_name            = "example.com site (heartbeat)"
+}
+
+resource "betteruptime_status_page_resource" "manually_tracked_item" {
+  status_page_id         = betteruptime_status_page.this.id
+  status_page_section_id = betteruptime_status_page_section.manually_tracked_items.id
+  resource_type          = "ManuallyTrackedItem"
+  public_name            = "example.com manual item"
 }
 
 resource "betteruptime_email_integration" "this" {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.7"
+      version = ">= 0.20.10"
     }
   }
 }

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -302,7 +302,7 @@ func validateStatusPageResource(ctx context.Context, d *schema.ResourceDiff, met
 func validateResourceTypeID(d *schema.ResourceDiff) error {
 	resourceType := d.Get("resource_type").(string)
 	_, hasResourceID := d.GetOk("resource_id")
-	if resourceType != "ManuallyTrackedItem" && !hasResourceID {
+	if resourceType != "ManuallyTrackedItem" && !hasResourceID && d.NewValueKnown("resource_id") {
 		return fmt.Errorf("resource_id is required when resource_type is %s", resourceType)
 	}
 	return nil

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -33,15 +33,16 @@ var statusPageResourceSchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"resource_id": {
-		Description: "The ID of the resource you are adding.",
+		Description: "The ID of the resource you are adding. Omit when resource_type is ManuallyTrackedItem.",
 		Type:        schema.TypeInt,
-		Required:    true,
+		Optional:    true,
+		Computed:    true,
 	},
 	"resource_type": {
-		Description:  "The type of the resource you are adding. Available values: Monitor, MonitorGroup, Heartbeat, HeartbeatGroup, WebhookIntegration, EmailIntegration, IncomingWebhook, ResourceGroup, LogsChart, CatalogReference.",
+		Description:  "The type of the resource you are adding. Available values: ManuallyTrackedItem, Monitor, MonitorGroup, Heartbeat, HeartbeatGroup, WebhookIntegration, EmailIntegration, IncomingWebhook, ResourceGroup, LogsChart, CatalogReference.",
 		Type:         schema.TypeString,
 		Required:     true,
-		ValidateFunc: validation.StringInSlice([]string{"Monitor", "MonitorGroup", "Heartbeat", "HeartbeatGroup", "WebhookIntegration", "EmailIntegration", "IncomingWebhook", "ResourceGroup", "LogsChart", "CatalogReference"}, false),
+		ValidateFunc: validation.StringInSlice([]string{"ManuallyTrackedItem", "Monitor", "MonitorGroup", "Heartbeat", "HeartbeatGroup", "WebhookIntegration", "EmailIntegration", "IncomingWebhook", "ResourceGroup", "LogsChart", "CatalogReference"}, false),
 	},
 	"public_name": {
 		Description: "The resource name displayed publicly on your status page.",
@@ -293,8 +294,18 @@ func statusPageResourceMetadataRuleCopyAttrs(d *schema.ResourceData, rule *map[s
 func validateStatusPageResource(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	degradedRuleError := validateMetadataRule(d, "mark_as_degraded_for", "mark_as_degraded_metadata_rule")
 	downRuleError := validateMetadataRule(d, "mark_as_down_for", "mark_as_down_metadata_rule")
+	resourceIDError := validateResourceTypeID(d)
 
-	return errors.Join(degradedRuleError, downRuleError)
+	return errors.Join(degradedRuleError, downRuleError, resourceIDError)
+}
+
+func validateResourceTypeID(d *schema.ResourceDiff) error {
+	resourceType := d.Get("resource_type").(string)
+	_, hasResourceID := d.GetOk("resource_id")
+	if resourceType != "ManuallyTrackedItem" && !hasResourceID {
+		return fmt.Errorf("resource_id is required when resource_type is %s", resourceType)
+	}
+	return nil
 }
 
 func validateMetadataRule(d *schema.ResourceDiff, keyFor string, keyMetadataRule string) error {

--- a/internal/provider/resource_status_page_resource_test.go
+++ b/internal/provider/resource_status_page_resource_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -181,6 +182,126 @@ func TestResourceStatusPageResource(t *testing.T) {
 				PreConfig: func() {
 					t.Log("step 6")
 				},
+			},
+		},
+	})
+}
+
+func TestResourceStatusPageResourceManuallyTrackedItem(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/status-pages/0/resources", "1")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create ManuallyTrackedItem without resource_id.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page_resource" "this" {
+					status_page_id = "0"
+					resource_type  = "ManuallyTrackedItem"
+					public_name    = "Manual Item"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_status_page_resource.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "public_name", "Manual Item"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "resource_type", "ManuallyTrackedItem"),
+					// Verify POST body does not contain resource_id.
+					server.TestCheckCalledRequest("POST", "/api/v2/status-pages/0/resources", `{"resource_type":"ManuallyTrackedItem","public_name":"Manual Item","fixed_position":true}`),
+				),
+				PreConfig: func() {
+					t.Log("step 1 - create ManuallyTrackedItem")
+				},
+			},
+			// Step 2 - PlanOnly no-op to verify no drift.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page_resource" "this" {
+					status_page_id = "0"
+					resource_type  = "ManuallyTrackedItem"
+					public_name    = "Manual Item"
+				}
+				`,
+				PlanOnly: true,
+				PreConfig: func() {
+					t.Log("step 2 - PlanOnly no-op")
+				},
+			},
+			// Step 3 - update public_name, verify PATCH body omits resource_id.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page_resource" "this" {
+					status_page_id = "0"
+					resource_type  = "ManuallyTrackedItem"
+					public_name    = "Updated Manual Item"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "public_name", "Updated Manual Item"),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/status-pages/0/resources/1", `{"public_name":"Updated Manual Item","fixed_position":true}`),
+				),
+				PreConfig: func() {
+					t.Log("step 3 - update public_name")
+				},
+			},
+			// Step 4 - import.
+			{
+				ResourceName:      "betteruptime_status_page_resource.this",
+				ImportState:       true,
+				ImportStateId:     "0/1",
+				ImportStateVerify: true,
+				PreConfig: func() {
+					t.Log("step 4 - import")
+				},
+			},
+		},
+	})
+}
+
+func TestResourceStatusPageResourceValidation(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/status-pages/0/resources", "1")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Monitor without resource_id should fail.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page_resource" "this" {
+					status_page_id = "0"
+					resource_type  = "Monitor"
+					public_name    = "Bad Config"
+				}
+				`,
+				ExpectError: regexp.MustCompile(`resource_id is required when resource_type is Monitor`),
 			},
 		},
 	})


### PR DESCRIPTION
- Adds support for `ManuallyTrackedItem` within status page's `resource_type`
- Adds conditional optionality for `resource_id`
- Adds tests

@PetrHeinz would you like me to manually test as well, or is the above enough? 🙏 