### PR TITLE
T-16886 Add proxy host and port into monitors

### DIFF
--- a/docs/data-sources/betteruptime_monitor.md
+++ b/docs/data-sources/betteruptime_monitor.md
@@ -84,6 +84,8 @@ Monitor lookup.
 - `policy_id` (String) Set the escalation policy for the monitor.
 - `port` (String) Required if monitor_type is set to tcp, udp, smtp, pop, or imap. tcp and udp monitors accept any ports, while smtp, pop, and imap accept only the specified ports corresponding with their servers (e.g. "25,465,587" for smtp).
 - `pronounceable_name` (String) Pronounceable name of the monitor. We will use this when we call you. Try to make it tongue-friendly, please?
+- `proxy_host` (String) A proxy to be used for routing HTTP checks. Use user:pass@hostname format for proxy authentication.
+- `proxy_port` (Number) The port to be used with `proxy_host`.
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the monitor must be up to automatically mark an incident as resolved after being down. In seconds.
 - `regions` (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -79,6 +79,8 @@ https://betterstack.com/docs/uptime/api/monitors/
 - `policy_id` (String) Set the escalation policy for the monitor.
 - `port` (String) Required if monitor_type is set to tcp, udp, smtp, pop, or imap. tcp and udp monitors accept any ports, while smtp, pop, and imap accept only the specified ports corresponding with their servers (e.g. "25,465,587" for smtp).
 - `pronounceable_name` (String) Pronounceable name of the monitor. We will use this when we call you. Try to make it tongue-friendly, please?
+- `proxy_host` (String) A proxy to be used for routing HTTP checks. Use user:pass@hostname format for proxy authentication.
+- `proxy_port` (Number) The port to be used with `proxy_host`.
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the monitor must be up to automatically mark an incident as resolved after being down. In seconds.
 - `regions` (List of String) An array of regions to set. Allowed values are ["us", "eu", "as", "au"] or any subset of these regions.

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -67,7 +67,7 @@ resource "betteruptime_monitor" "status" {
   expiration_policy_id = betteruptime_policy.this.id
   domain_expiration    = -1 # Disable domain expiration check
   ssl_expiration       = -1 # Disable SSL expiration check
-  proxy_host           = "192.168.0.1"
+  proxy_host           = "user:pass@proxy.example.com"
   proxy_port           = 8080
   request_headers = [
     {

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -67,6 +67,8 @@ resource "betteruptime_monitor" "status" {
   expiration_policy_id = betteruptime_policy.this.id
   domain_expiration    = -1 # Disable domain expiration check
   ssl_expiration       = -1 # Disable SSL expiration check
+  proxy_host           = "192.168.0.1"
+  proxy_port           = 8080
   request_headers = [
     {
       "name" : "X-For-Status-Page",

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -294,7 +294,16 @@ var monitorSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Sensitive:   true,
 	},
-
+	"proxy_host": {
+		Description: "A proxy to be used for routing HTTP checks. Use user:pass@hostname format for proxy authentication.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
+	"proxy_port": {
+		Description: "The port to be used with `proxy_host`.",
+		Type:        schema.TypeInt,
+		Optional:    true,
+	},
 	"ip_version": {
 		Description: strings.ReplaceAll(`Valid values:
 
@@ -476,6 +485,8 @@ type monitor struct {
 	RequestHeaders       *[]map[string]interface{} `json:"request_headers,omitempty"`
 	AuthUsername         *string                   `json:"auth_username,omitempty"`
 	AuthPassword         *string                   `json:"auth_password,omitempty"`
+	ProxyHost            *string                   `json:"proxy_host,omitempty"`
+	ProxyPort            *int                      `json:"proxy_port,omitempty"`
 	IpVersion            *string                   `json:"ip_version,omitempty"`
 	MaintenanceFrom      *string                   `json:"maintenance_from,omitempty"`
 	MaintenanceTo        *string                   `json:"maintenance_to,omitempty"`
@@ -539,6 +550,8 @@ func monitorRef(in *monitor) []struct {
 		{k: "request_headers", v: &in.RequestHeaders},
 		{k: "auth_username", v: &in.AuthUsername},
 		{k: "auth_password", v: &in.AuthPassword},
+		{k: "proxy_host", v: &in.ProxyHost},
+		{k: "proxy_port", v: &in.ProxyPort},
 		{k: "ip_version", v: &in.IpVersion},
 		{k: "maintenance_from", v: &in.MaintenanceFrom},
 		{k: "maintenance_to", v: &in.MaintenanceTo},


### PR DESCRIPTION
- Support `proxy_host` and `proxy_port` on **betteruptime_monitor**