### PR TITLE
[STA-2574] Add mobile_app_platforms to team members

### DIFF
--- a/docs/data-sources/betteruptime_team_member.md
+++ b/docs/data-sources/betteruptime_team_member.md
@@ -31,6 +31,7 @@ Team member lookup by email.
 - `invited_at` (String) The timestamp when the invitation was sent.
 - `last_name` (String) The last name of the team member (available after invitation is accepted).
 - `member_id` (String) The numeric ID of the team member. Empty for pending invitations.
+- `mobile_app_platforms` (List of String) The mobile app platforms the team member has installed (e.g. ios, android).
 - `role` (String) The role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder.
 
 

--- a/docs/resources/betteruptime_team_member.md
+++ b/docs/resources/betteruptime_team_member.md
@@ -32,5 +32,6 @@ Allows managing **non-admin team members** using Terraform. Learn more about [in
 - `invited_at` (String) The timestamp when the invitation was sent.
 - `last_name` (String) The last name of the team member (available after invitation is accepted).
 - `member_id` (String) The numeric ID of the team member. Empty for pending invitations.
+- `mobile_app_platforms` (List of String) The mobile app platforms the team member has installed (e.g. ios, android).
 
 

--- a/internal/provider/data_team_member_test.go
+++ b/internal/provider/data_team_member_test.go
@@ -20,7 +20,7 @@ func TestDataTeamMember(t *testing.T) {
 
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/team-members?email=petr%40betterstack.com":
-			_, _ = w.Write([]byte(`{"data":{"id":"7","type":"team_member","attributes":{"email":"petr@betterstack.com","first_name":"Petr","last_name":"Heinz","created_at":"2024-01-15T08:00:00Z","role":"admin"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"id":"7","type":"team_member","attributes":{"email":"petr@betterstack.com","first_name":"Petr","last_name":"Heinz","created_at":"2024-01-15T08:00:00Z","role":"admin","mobile_app_platforms":["ios","android"]}}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
 		}
@@ -53,6 +53,9 @@ func TestDataTeamMember(t *testing.T) {
 					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "role", "admin"),
 					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "member_id", "7"),
 					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "created_at", "2024-01-15T08:00:00Z"),
+					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "mobile_app_platforms.#", "2"),
+					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "mobile_app_platforms.0", "ios"),
+					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "mobile_app_platforms.1", "android"),
 				),
 			},
 		},
@@ -69,7 +72,7 @@ func TestDataTeamMemberInvitation(t *testing.T) {
 
 		switch {
 		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/team-members?email=invited%40example.com":
-			_, _ = w.Write([]byte(`{"data":{"id":null,"type":"team_member_invitation","attributes":{"email":"invited@example.com","first_name":null,"last_name":null,"invited_at":"2026-03-01T12:00:00Z","role":"responder"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"id":null,"type":"team_member_invitation","attributes":{"email":"invited@example.com","first_name":null,"last_name":null,"invited_at":"2026-03-01T12:00:00Z","role":"responder","mobile_app_platforms":[]}}}`))
 		default:
 			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
 		}
@@ -102,6 +105,7 @@ func TestDataTeamMemberInvitation(t *testing.T) {
 					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "first_name", ""),
 					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "last_name", ""),
 					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "invited_at", "2026-03-01T12:00:00Z"),
+					resource.TestCheckResourceAttr("data.betteruptime_team_member.this", "mobile_app_platforms.#", "0"),
 				),
 			},
 		},

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -61,16 +61,23 @@ var teamMemberSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Computed:    true,
 	},
+	"mobile_app_platforms": {
+		Description: "The mobile app platforms the team member has installed (e.g. ios, android).",
+		Type:        schema.TypeList,
+		Computed:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString},
+	},
 }
 
 type teamMember struct {
-	Email     *string `json:"email,omitempty"`
-	Role      *string `json:"role,omitempty"`
-	TeamName  *string `json:"team_name,omitempty"`
-	FirstName *string `json:"first_name,omitempty"`
-	LastName  *string `json:"last_name,omitempty"`
-	CreatedAt *string `json:"created_at,omitempty"`
-	InvitedAt *string `json:"invited_at,omitempty"`
+	Email              *string  `json:"email,omitempty"`
+	Role               *string  `json:"role,omitempty"`
+	TeamName           *string  `json:"team_name,omitempty"`
+	FirstName          *string  `json:"first_name,omitempty"`
+	LastName           *string  `json:"last_name,omitempty"`
+	CreatedAt          *string  `json:"created_at,omitempty"`
+	InvitedAt          *string  `json:"invited_at,omitempty"`
+	MobileAppPlatforms []string `json:"mobile_app_platforms,omitempty"`
 }
 
 type teamMemberHTTPResponse struct {
@@ -221,6 +228,7 @@ func teamMemberCopyAttrs(d *schema.ResourceData, out *teamMemberHTTPResponse) di
 	set("last_name", ptrToStr(a.LastName))
 	set("created_at", ptrToStr(a.CreatedAt))
 	set("invited_at", ptrToStr(a.InvitedAt))
+	set("mobile_app_platforms", a.MobileAppPlatforms)
 	return derr
 }
 

--- a/internal/provider/resource_team_member_test.go
+++ b/internal/provider/resource_team_member_test.go
@@ -24,14 +24,14 @@ func TestResourceTeamMember(t *testing.T) {
 		case r.Method == http.MethodPost && r.RequestURI == "/api/v2/team-members":
 			created = true
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"message":"Invitation sent","data":{"id":null,"type":"team_member_invitation","attributes":{"email":"test@example.com","first_name":null,"last_name":null,"invited_at":"2026-01-01T00:00:00Z","role":"responder"}}}`))
+			_, _ = w.Write([]byte(`{"message":"Invitation sent","data":{"id":null,"type":"team_member_invitation","attributes":{"email":"test@example.com","first_name":null,"last_name":null,"invited_at":"2026-01-01T00:00:00Z","role":"responder","mobile_app_platforms":[]}}}`))
 		case r.Method == http.MethodGet && strings.HasPrefix(r.RequestURI, "/api/v2/team-members?email="):
 			if !created {
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write([]byte(`{"errors":"Team member with email \"test@example.com\" not found"}`))
 				return
 			}
-			_, _ = w.Write([]byte(`{"data":{"id":null,"type":"team_member_invitation","attributes":{"email":"test@example.com","first_name":null,"last_name":null,"invited_at":"2026-01-01T00:00:00Z","role":"responder"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"id":null,"type":"team_member_invitation","attributes":{"email":"test@example.com","first_name":null,"last_name":null,"invited_at":"2026-01-01T00:00:00Z","role":"responder","mobile_app_platforms":[]}}}`))
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, "/api/v2/team-members?email="):
 			created = false
 			w.WriteHeader(http.StatusNoContent)
@@ -66,6 +66,7 @@ func TestResourceTeamMember(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_team_member.this", "role", "responder"),
 					resource.TestCheckResourceAttr("betteruptime_team_member.this", "invited_at", "2026-01-01T00:00:00Z"),
 					resource.TestCheckResourceAttr("betteruptime_team_member.this", "member_id", ""),
+					resource.TestCheckResourceAttr("betteruptime_team_member.this", "mobile_app_platforms.#", "0"),
 				),
 			},
 			// No changes — plan should be empty.
@@ -97,9 +98,9 @@ func TestResourceTeamMemberExistingUser(t *testing.T) {
 		switch {
 		case r.Method == http.MethodPost && r.RequestURI == "/api/v2/team-members":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"message":"User is already a member of the team","data":{"id":"42","type":"team_member","attributes":{"email":"existing@example.com","first_name":"Jane","last_name":"Doe","created_at":"2025-06-15T10:30:00Z","role":"admin"}}}`))
+			_, _ = w.Write([]byte(`{"message":"User is already a member of the team","data":{"id":"42","type":"team_member","attributes":{"email":"existing@example.com","first_name":"Jane","last_name":"Doe","created_at":"2025-06-15T10:30:00Z","role":"admin","mobile_app_platforms":["ios"]}}}`))
 		case r.Method == http.MethodGet && strings.HasPrefix(r.RequestURI, "/api/v2/team-members?email="):
-			_, _ = w.Write([]byte(`{"data":{"id":"42","type":"team_member","attributes":{"email":"existing@example.com","first_name":"Jane","last_name":"Doe","created_at":"2025-06-15T10:30:00Z","role":"admin"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"id":"42","type":"team_member","attributes":{"email":"existing@example.com","first_name":"Jane","last_name":"Doe","created_at":"2025-06-15T10:30:00Z","role":"admin","mobile_app_platforms":["ios"]}}}`))
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, "/api/v2/team-members?email="):
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -134,6 +135,8 @@ func TestResourceTeamMemberExistingUser(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_team_member.this", "last_name", "Doe"),
 					resource.TestCheckResourceAttr("betteruptime_team_member.this", "member_id", "42"),
 					resource.TestCheckResourceAttr("betteruptime_team_member.this", "created_at", "2025-06-15T10:30:00Z"),
+					resource.TestCheckResourceAttr("betteruptime_team_member.this", "mobile_app_platforms.#", "1"),
+					resource.TestCheckResourceAttr("betteruptime_team_member.this", "mobile_app_platforms.0", "ios"),
 				),
 			},
 		},
@@ -154,13 +157,13 @@ func TestResourceTeamMemberImport(t *testing.T) {
 		case r.Method == http.MethodPost && r.RequestURI == "/api/v2/team-members":
 			created = true
 			w.WriteHeader(http.StatusCreated)
-			_, _ = w.Write([]byte(`{"message":"Invitation sent","data":{"id":null,"type":"team_member_invitation","attributes":{"email":"import@example.com","first_name":null,"last_name":null,"invited_at":"2026-02-01T00:00:00Z","role":"member"}}}`))
+			_, _ = w.Write([]byte(`{"message":"Invitation sent","data":{"id":null,"type":"team_member_invitation","attributes":{"email":"import@example.com","first_name":null,"last_name":null,"invited_at":"2026-02-01T00:00:00Z","role":"member","mobile_app_platforms":[]}}}`))
 		case r.Method == http.MethodGet && strings.HasPrefix(r.RequestURI, "/api/v2/team-members?email="):
 			if !created {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			_, _ = w.Write([]byte(`{"data":{"id":null,"type":"team_member_invitation","attributes":{"email":"import@example.com","first_name":null,"last_name":null,"invited_at":"2026-02-01T00:00:00Z","role":"member"}}}`))
+			_, _ = w.Write([]byte(`{"data":{"id":null,"type":"team_member_invitation","attributes":{"email":"import@example.com","first_name":null,"last_name":null,"invited_at":"2026-02-01T00:00:00Z","role":"member","mobile_app_platforms":[]}}}`))
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.RequestURI, "/api/v2/team-members?email="):
 			created = false
 			w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Summary
- Adds read-only `mobile_app_platforms` attribute to the team members resource and data source
- Returns an array of platforms (e.g. `["ios", "android"]`) per team member from the API

## Related
- https://github.com/BetterStackHQ/betterstack/pull/5014

## Test plan
- [ ] Verify `mobile_app_platforms` is available as a computed attribute on `betterstack_team_member` resource and data source
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)