### PR TITLE
T-17540 Pre-install terraform in unit-test CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,14 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 'latest'
+        # Disable the wrapper: on Windows it creates a `terraform` file with
+        # no extension that is not discoverable via PATHEXT, so go test falls
+        # back to hc-install and trips the expired GPG check.
+        terraform_wrapper: false
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test


### PR DESCRIPTION
## Summary

The `test` job in `.github/workflows/test.yml` fails with:

```
cannot run Terraform provider tests: failed to find or install Terraform CLI:
unable to verify checksums signature: openpgp: key expired
```

### Why

`terraform-plugin-sdk`'s test framework auto-downloads the `terraform` binary via `hc-install` when none is on `PATH`. `hc-install` verifies HashiCorp release checksums against a hardcoded GPG public key whose expiration date has passed, so the download fails before any Go test runs. Affects every provider SDK consumer, not just this repo.

### Fix

Pre-install terraform via `hashicorp/setup-terraform@v3` — the same step the `e2e_test` job already uses. The action pulls the binary directly from HashiCorp releases and puts it on `PATH`, so the SDK skips `hc-install`'s GPG-verified download entirely.

`terraform_wrapper: false` is required because on Windows the default wrapper creates a file named `terraform` (no extension) that `exec.LookPath` cannot resolve through `PATHEXT`, causing the fallback to hc-install even with the action installed.

### Related

Same fix landed in `terraform-provider-logtail` via https://github.com/BetterStackHQ/terraform-provider-logtail/pull/73. T-17540.

## Test plan

- [ ] After merge, confirm the `test` job matrix (ubuntu / macos / windows on Go 1.23.x) runs `go test ./...` to completion instead of failing on the GPG check.
