### PR TITLE
Bump version to v0.20.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.15
+VERSION := 0.20.16
 .PHONY: test build
 
 help:

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.15"
+      version = ">= 0.20.16"
     }
   }
 }


### PR DESCRIPTION
v0.20.15 was released without the on_incident_comment change (#199), so bump to v0.20.16 to publish that feature