### PR TITLE
U-8581: Add title_field to email_integration resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.16
+VERSION := 0.20.17
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_email_integration.md
+++ b/docs/resources/betteruptime_email_integration.md
@@ -44,6 +44,7 @@ https://betterstack.com/docs/uptime/api/email-integrations/
 - `started_rules` (Block List) An array of rules to match to start a new incident. (see [below for nested schema](#nestedblock--started_rules))
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team.
+- `title_field` (Block List, Max: 1) An optional field describing how to extract a customized incident title. (see [below for nested schema](#nestedblock--title_field))
 
 ### Read-Only
 
@@ -188,5 +189,20 @@ Optional:
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
+
+
+<a id="nestedblock--title_field"></a>
+### Nested Schema for `title_field`
+
+Optional:
+
+- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
+- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
+- `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
+- `name` (String) The name of the field.
+- `special_type` (String) A special type of the field. Can be alert_id or cause or otherwise null for a custom field.
+- `target_field` (String) The target field within the content of the field_target. Should be a JSON key when field_target is json, a CSS selector when field_target is XML, name of the header for headers or a parameter name for query parameters
 
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -204,6 +204,14 @@ resource "betteruptime_email_integration" "this" {
     field_target = "subject"
     match_type   = "match_everything"
   }
+  title_field {
+    name           = "Title"
+    special_type   = "title"
+    field_target   = "subject"
+    match_type     = "match_between"
+    content_before = "["
+    content_after  = "]"
+  }
   started_alert_id_field {
     name           = "Alert ID"
     special_type   = "alert_id"

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.16"
+      version = ">= 0.20.17"
     }
   }
 }

--- a/internal/provider/resource_email_integration.go
+++ b/internal/provider/resource_email_integration.go
@@ -136,6 +136,14 @@ var emailIntegrationSchema = map[string]*schema.Schema{
 		Computed:    true,
 		MaxItems:    1,
 	},
+	"title_field": {
+		Description: "An optional field describing how to extract a customized incident title.",
+		Type:        schema.TypeList,
+		Elem:        &schema.Resource{Schema: integrationFieldSchema},
+		Optional:    true,
+		Computed:    true,
+		MaxItems:    1,
+	},
 	"started_alert_id_field": {
 		Description: "When starting an incident, how to extract an alert id, a unique alert identifier which will be used to acknowledge and resolve incidents.",
 		Type:        schema.TypeList,
@@ -229,6 +237,7 @@ type emailIntegration struct {
 	AcknowledgedRules        *[]integrationRule  `json:"acknowledged_rules,omitempty"`
 	ResolvedRules            *[]integrationRule  `json:"resolved_rules,omitempty"`
 	CauseField               *integrationField   `json:"cause_field,omitempty"`
+	TitleField               *integrationField   `json:"title_field,omitempty"`
 	StartedAlertIdField      *integrationField   `json:"started_alert_id_field,omitempty"`
 	AcknowledgedAlertIdField *integrationField   `json:"acknowledged_alert_id_field,omitempty"`
 	ResolvedAlertIdField     *integrationField   `json:"resolved_alert_id_field,omitempty"`
@@ -274,6 +283,7 @@ func emailIntegrationRef(in *emailIntegration) []struct {
 		{k: "acknowledged_rules", v: &in.AcknowledgedRules},
 		{k: "resolved_rules", v: &in.ResolvedRules},
 		{k: "cause_field", v: &in.CauseField},
+		{k: "title_field", v: &in.TitleField},
 		{k: "started_alert_id_field", v: &in.StartedAlertIdField},
 		{k: "acknowledged_alert_id_field", v: &in.AcknowledgedAlertIdField},
 		{k: "resolved_alert_id_field", v: &in.ResolvedAlertIdField},

--- a/internal/provider/resource_email_integration_test.go
+++ b/internal/provider/resource_email_integration_test.go
@@ -62,6 +62,14 @@ func TestResourceEmailIntegration(t *testing.T) {
 					field_target = "subject"
 					match_type = "match_everything"
 				  }
+				  title_field {
+					name = "Title"
+					special_type = "title"
+					field_target = "subject"
+					match_type = "match_between"
+					content_before = "["
+					content_after = "]"
+				  }
 				  started_alert_id_field {
 					name = "Alert ID"
 					special_type = "alert_id"
@@ -102,6 +110,9 @@ func TestResourceEmailIntegration(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "resolved_rules.0.match_type", "contains"),
 					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "resolved_rules.0.content", "[Resolved Alert]"),
 					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "cause_field.0.match_type", "match_everything"),
+					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "title_field.0.special_type", "title"),
+					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "title_field.0.content_before", "["),
+					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "title_field.0.content_after", "]"),
 					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "started_alert_id_field.0.content_before", "]"),
 					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "resolved_alert_id_field.0.content_after", ")"),
 					resource.TestCheckResourceAttr("betteruptime_email_integration.this", "other_started_fields.0.content_before", "by:"),
@@ -153,6 +164,14 @@ func TestResourceEmailIntegration(t *testing.T) {
 					special_type = "cause"
 					field_target = "subject"
 					match_type = "match_everything"
+				  }
+				  title_field {
+					name = "Title"
+					special_type = "title"
+					field_target = "subject"
+					match_type = "match_between"
+					content_before = "["
+					content_after = "]"
 				  }
 				  started_alert_id_field {
 					name = "Alert ID"
@@ -239,6 +258,14 @@ func TestResourceEmailIntegration(t *testing.T) {
 					special_type = "cause"
 					field_target = "subject"
 					match_type = "match_everything"
+				  }
+				  title_field {
+					name = "Title"
+					special_type = "title"
+					field_target = "subject"
+					match_type = "match_between"
+					content_before = "["
+					content_after = "]"
 				  }
 				  started_alert_id_field {
 					name = "Alert ID"


### PR DESCRIPTION
## Summary
- Adds `title_field` block to the `betteruptime_email_integration` resource, mirroring the API change in [worktree-red-sparrow/uptime#10242](https://github.com/BetterStackHQ/uptime/pull/10242) (U-8581, commit `b74d35b43`), which exposed `title_field` on `EmailIntegrationSerializer`.
- Resolves the `Dev::TerraformMissingArgumentsCheckWorker` alert fired in `#infrastructure`: *"Betteruptime terraform resources missing arguments: betteruptime_email_integration → [title_field]"*.
- The shared `FieldAttributes` list in `integration_schemas.go` already included `title_field` (added in #113 when IncomingWebhook got the same field), so existing load/store plumbing covers it without further change.

## Changes
- `internal/provider/resource_email_integration.go`: schema entry, struct field, and ref entry (3 mechanical additions next to `cause_field`).
- `internal/provider/resource_email_integration_test.go`: `title_field` block in all three lifecycle steps + assertions on `special_type`, `content_before`, `content_after`.
- `docs/resources/betteruptime_email_integration.md`: regenerated via `make gen`.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` (incl. mock-server acceptance test)
- [x] `make gen` produces no further doc changes
- [x] `terraform fmt -check -recursive` clean
- [x] CI `tests` (Linux/macOS/Windows × Go 1.23) and `build` (lint + check_docs) green