### PR TITLE
[U-8896] Add server_timezone param to heartbeats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.17
+VERSION := 0.20.18
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_heartbeat.md
+++ b/docs/resources/betteruptime_heartbeat.md
@@ -34,6 +34,7 @@ https://betterstack.com/docs/uptime/api/heartbeats/
 - `paused` (Boolean) Set to true to pause monitoring — we won't notify you about downtime. Set to false to resume monitoring.
 - `policy_id` (String) Set the escalation policy for the heartbeat.
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
+- `server_timezone` (String) The IANA timezone (e.g. "Europe/Berlin") used to evaluate this heartbeat's period against wall-clock time, keeping daily and cron-style schedules aligned across daylight saving time changes. Only applies to periods of 1 hour or longer; it is cleared for shorter periods.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `sort_index` (Number) An index controlling the position of a heartbeat in the heartbeat group.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -148,9 +148,11 @@ resource "betteruptime_heartbeat_group" "this" {
 
 resource "betteruptime_heartbeat" "this" {
   name               = "example.com heartbeat"
-  period             = 30
+  period             = 3600
   grace              = 0
   heartbeat_group_id = betteruptime_heartbeat_group.this.id
+  # Keep cron-style checks aligned across DST; only applies to periods of 1 hour or longer
+  server_timezone = "Europe/Berlin"
 }
 
 resource "betteruptime_status_page_resource" "heartbeat" {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.17"
+      version = ">= 0.20.18"
     }
   }
 }

--- a/internal/provider/resource_heartbeat.go
+++ b/internal/provider/resource_heartbeat.go
@@ -49,6 +49,11 @@ var heartbeatSchema = map[string]*schema.Schema{
 		Required:    true,
 		// TODO: ValidateDiagFunc
 	},
+	"server_timezone": {
+		Description: "The IANA timezone (e.g. \"Europe/Berlin\") used to evaluate this heartbeat's period against wall-clock time, keeping daily and cron-style schedules aligned across daylight saving time changes. Only applies to periods of 1 hour or longer; it is cleared for shorter periods.",
+		Type:        schema.TypeString,
+		Optional:    true,
+	},
 	"call": {
 		Description: "Whether to call when a new incident is created.",
 		Type:        schema.TypeBool,
@@ -185,6 +190,7 @@ type heartbeat struct {
 	Url                 *string   `json:"url,omitempty"`
 	Period              *int      `json:"period,omitempty"`
 	Grace               *int      `json:"grace,omitempty"`
+	ServerTimezone      *string   `json:"server_timezone,omitempty"`
 	Call                *bool     `json:"call,omitempty"`
 	SMS                 *bool     `json:"sms,omitempty"`
 	Email               *bool     `json:"email,omitempty"`
@@ -226,6 +232,7 @@ func heartbeatRef(in *heartbeat) []struct {
 		{k: "url", v: &in.Url},
 		{k: "period", v: &in.Period},
 		{k: "grace", v: &in.Grace},
+		{k: "server_timezone", v: &in.ServerTimezone},
 		{k: "call", v: &in.Call},
 		{k: "sms", v: &in.SMS},
 		{k: "email", v: &in.Email},

--- a/internal/provider/resource_heartbeat_test.go
+++ b/internal/provider/resource_heartbeat_test.go
@@ -179,3 +179,112 @@ func TestResourceHeartbeat(t *testing.T) {
 		},
 	})
 }
+
+func TestResourceHeartbeatServerTimezone(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/heartbeats", "1")
+	defer server.Close()
+
+	var name = "example"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create with a server timezone. Period is >= 1h, below which the API drops server_timezone.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_heartbeat" "this" {
+					name            = "%s"
+					period          = 3600
+					grace           = 0
+					call            = false
+					sms             = true
+					email           = true
+					push            = true
+					critical_alert  = false
+					server_timezone = "Europe/Berlin"
+				}
+				`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_heartbeat.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "server_timezone", "Europe/Berlin"),
+				),
+			},
+			// Step 2 - change only the timezone, expect only it to be patched.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_heartbeat" "this" {
+					name            = "%s"
+					period          = 3600
+					grace           = 0
+					call            = false
+					sms             = true
+					email           = true
+					push            = true
+					critical_alert  = false
+					server_timezone = "America/New_York"
+				}
+				`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "server_timezone", "America/New_York"),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"server_timezone":"America/New_York"}`),
+				),
+			},
+			// Step 3 - drop the timezone, expect only it to be cleared.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_heartbeat" "this" {
+					name           = "%s"
+					period         = 3600
+					grace          = 0
+					call           = false
+					sms            = true
+					email          = true
+					push           = true
+					critical_alert = false
+				}
+				`, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_heartbeat.this", "server_timezone", ""),
+					server.TestCheckCalledRequest("PATCH", "/api/v2/heartbeats/1", `{"server_timezone":""}`), // Understood as null by API
+				),
+			},
+			// Step 4 - make no changes, check plan is empty.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_heartbeat" "this" {
+					name           = "%s"
+					period         = 3600
+					grace          = 0
+					call           = false
+					sms            = true
+					email          = true
+					push           = true
+					critical_alert = false
+				}
+				`, name),
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Exposes the heartbeat server_timezone attribute (already supported by the API) in the Terraform provider: schema, struct, ref mapping, regenerated docs, and an advanced example. Modeled as Optional-only (not Computed) so it stays clearable to null, matching policy_id. The API drops it for sub-hour periods, so the example uses a 1h period.