### PR TITLE
Bump version to v0.20.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.18
+VERSION := 0.20.19
 .PHONY: test build
 
 help:

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.18"
+      version = ">= 0.20.19"
     }
   }
 }


### PR DESCRIPTION
A merge race left the embedded VERSION (Makefile, examples/advanced/ versions.tf) at 0.20.18 on master -- a value already released by #202 -- so it no longer matched the latest tag. Bump it to 0.20.19 to match the release cut from the #203 merge.

When the divergence happened -- three distinct moments:

1. The number got claimed -- May 28, 13:14. v0.20.18 was cut from #202 (7b215fe). From this instant, 0.20.18 was a released version.

2. The duplicate bump was written -- May 29, 14:38. The U-8896 branch (282a0fd) was cut from 840f550 (#201, the last release its author saw, v0.20.17), not from current master. Working off that stale base it bumped 0.20.17 -> 0.20.18, a value that had already shipped the day before. The branch was never rebased onto #202.

3. The divergence materialized on master -- Jun 1, 11:14. When #203 was squash-merged as 816668a onto master (already at 0.20.18 from #202), Git's 3-way merge of that line saw base 0.20.17, ours 0.20.18, theirs 0.20.18 -- both sides changed it to the identical value, so there was no conflict and it merged silently. 816668a is the first commit whose embedded VERSION (0.20.18) does not match the commit its tag points to (v0.20.18 -> 7b215fe).

Root cause: both #202 and #203 branched off #201 (0.20.17) and both bumped to 0.20.18; whichever merged second re-claimed a taken version with no conflict to flag it. Bump against current master, not an old release base, to avoid repeating this.