### PR TITLE
U-7076 Stabilize catalog record attribute order

### DIFF
--- a/internal/provider/resource_catalog_record.go
+++ b/internal/provider/resource_catalog_record.go
@@ -208,6 +208,12 @@ func catalogRecordDelete(ctx context.Context, d *schema.ResourceData, meta inter
 func catalogRecordCopyAttrs(d *schema.ResourceData, in *catalogRecord) diag.Diagnostics {
 	attributes := flattenCatalogRecordAttributes(in.Attributes)
 
+	// The catalog API does not guarantee a stable attribute order. Because `attribute` is an
+	// ordered TypeList, a reordered API response would otherwise show up as a spurious plan diff
+	// (U-7076). Reorder to match the configured/prior-state order before storing. This also keeps
+	// the index-based cleanup below aligned with the configuration.
+	attributes = reorderCatalogRecordAttributes(d, attributes)
+
 	// Remove item_id, name, and email from attributes if they were not configured, avoid loading them from API
 	for attributeIndex, attribute := range attributes {
 		attributeMap := attribute.(map[string]interface{})
@@ -222,6 +228,88 @@ func catalogRecordCopyAttrs(d *schema.ResourceData, in *catalogRecord) diag.Diag
 		return diag.FromErr(err)
 	}
 	return nil
+}
+
+// reorderCatalogRecordAttributes reorders the flattened attributes returned by the API to
+// match the order they appear in the configuration (or prior state). The catalog API does not
+// guarantee a stable order, and because `attribute` is an ordered TypeList an order-only change
+// would otherwise produce a spurious plan diff (U-7076). Each existing block is matched to an
+// API attribute by attribute_id, preferring an exact value-signature match so that multiple
+// values sharing an attribute_id are paired correctly; any attributes the API returns that are
+// not present in the configuration are appended at the end.
+func reorderCatalogRecordAttributes(d *schema.ResourceData, attributes []interface{}) []interface{} {
+	existing, ok := d.Get("attribute").([]interface{})
+	if !ok || len(existing) == 0 {
+		return attributes
+	}
+
+	used := make([]bool, len(attributes))
+	ordered := make([]interface{}, 0, len(attributes))
+
+	findMatch := func(match func(map[string]interface{}) bool) int {
+		for i, attr := range attributes {
+			if used[i] {
+				continue
+			}
+			if match(attr.(map[string]interface{})) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	for _, e := range existing {
+		em, ok := e.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		wantID := catalogAttributeID(em)
+		wantSig := catalogAttributeSignature(em)
+
+		// Prefer an exact value-signature match to disambiguate multiple values that share an
+		// attribute_id; fall back to matching on attribute_id alone.
+		idx := findMatch(func(m map[string]interface{}) bool {
+			return catalogAttributeSignature(m) == wantSig
+		})
+		if idx == -1 {
+			idx = findMatch(func(m map[string]interface{}) bool {
+				return catalogAttributeID(m) == wantID
+			})
+		}
+		if idx >= 0 {
+			used[idx] = true
+			ordered = append(ordered, attributes[idx])
+		}
+	}
+
+	// Append any attributes the API returned that weren't matched to the config/prior state.
+	for i, attr := range attributes {
+		if !used[i] {
+			ordered = append(ordered, attr)
+		}
+	}
+
+	return ordered
+}
+
+func catalogAttributeID(m map[string]interface{}) string {
+	id, _ := m["attribute_id"].(string)
+	return id
+}
+
+func catalogAttributeSignature(m map[string]interface{}) string {
+	field := func(k string) string {
+		v, _ := m[k].(string)
+		return v
+	}
+	return strings.Join([]string{
+		field("attribute_id"),
+		field("type"),
+		field("value"),
+		field("item_id"),
+		field("name"),
+		field("email"),
+	}, "\x00")
 }
 
 func validateCatalogRecordAttributes(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {

--- a/internal/provider/resource_catalog_record.go
+++ b/internal/provider/resource_catalog_record.go
@@ -209,8 +209,8 @@ func catalogRecordCopyAttrs(d *schema.ResourceData, in *catalogRecord) diag.Diag
 	attributes := flattenCatalogRecordAttributes(in.Attributes)
 
 	// The catalog API does not guarantee a stable attribute order. Because `attribute` is an
-	// ordered TypeList, a reordered API response would otherwise show up as a spurious plan diff
-	// (U-7076). Reorder to match the configured/prior-state order before storing. This also keeps
+	// ordered TypeList, a reordered API response would otherwise show up as a spurious plan diff.
+	// Reorder to match the configured/prior-state order before storing. This also keeps
 	// the index-based cleanup below aligned with the configuration.
 	attributes = reorderCatalogRecordAttributes(d, attributes)
 
@@ -233,7 +233,7 @@ func catalogRecordCopyAttrs(d *schema.ResourceData, in *catalogRecord) diag.Diag
 // reorderCatalogRecordAttributes reorders the flattened attributes returned by the API to
 // match the order they appear in the configuration (or prior state). The catalog API does not
 // guarantee a stable order, and because `attribute` is an ordered TypeList an order-only change
-// would otherwise produce a spurious plan diff (U-7076). Each existing block is matched to an
+// would otherwise produce a spurious plan diff. Each existing block is matched to an
 // API attribute by attribute_id, preferring an exact value-signature match so that multiple
 // values sharing an attribute_id are paired correctly; any attributes the API returns that are
 // not present in the configuration are appended at the end.

--- a/internal/provider/resource_catalog_record_test.go
+++ b/internal/provider/resource_catalog_record_test.go
@@ -55,6 +55,88 @@ func TestResourceCatalogRecord(t *testing.T) {
 	})
 }
 
+// TestResourceCatalogRecordAttributeOrderStable guards against U-7076: the catalog API may
+// return a record's attributes in a different order than they were configured. Because
+// `attribute` is an ordered TypeList, the provider must reorder the API response back to the
+// configured order so that an order-only difference never surfaces as a (non-empty) plan.
+func TestResourceCatalogRecordAttributeOrderStable(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/catalog/relations/123/records", "2")
+	defer server.Close()
+
+	// On read, return the two attributes in the reverse of the configured order.
+	server.ExpectRequest("GET", "/api/v2/catalog/relations/123/records/2", "", 200,
+		`{"data":{"id":"2","attributes":{"attributes":[`+
+			`{"attribute":{"id":"790"},"values":[{"type":"String","value":"Beta"}]},`+
+			`{"attribute":{"id":"789"},"values":[{"type":"String","value":"Alpha"}]}`+
+			`]}}}`)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_catalog_record" "test" {
+					relation_id = "123"
+
+					attribute {
+						attribute_id = "789"
+						type        = "String"
+						value       = "Alpha"
+					}
+
+					attribute {
+						attribute_id = "790"
+						type        = "String"
+						value       = "Beta"
+					}
+				}
+				`,
+				// The post-apply refresh reads the reversed order; without reordering this step
+				// fails with a non-empty plan. The explicit checks document the expected order.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.#", "2"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.0.attribute_id", "789"),
+					resource.TestCheckResourceAttr("betteruptime_catalog_record.test", "attribute.1.attribute_id", "790"),
+				),
+			},
+			// Plan again against the reversed read: must be empty.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_catalog_record" "test" {
+					relation_id = "123"
+
+					attribute {
+						attribute_id = "789"
+						type        = "String"
+						value       = "Alpha"
+					}
+
+					attribute {
+						attribute_id = "790"
+						type        = "String"
+						value       = "Beta"
+					}
+				}
+				`,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestResourceCatalogRecordValidation(t *testing.T) {
 	server := newResourceServer(t, "/api/v2/catalog/relations/123/records", "2")
 	defer server.Close()


### PR DESCRIPTION
The catalog API does not guarantee a stable order for a record's attributes. Because `attribute` is an ordered TypeList, a reordered API response surfaced as a spurious (non-empty) plan and intermittently failed the examples/catalog E2E.

Reorder the flattened API attributes to match the configured / prior-state order in catalogRecordCopyAttrs, matched by attribute_id (preferring an exact value-signature match to pair multi-value blocks correctly). This also keeps the index-based item_id/name/email cleanup aligned with the configuration.