### PR TITLE
Reject changing team_name after a resource is created

### DIFF
--- a/docs/resources/betteruptime_aws_cloudwatch_integration.md
+++ b/docs/resources/betteruptime_aws_cloudwatch_integration.md
@@ -26,7 +26,7 @@ https://betterstack.com/docs/uptime/api/aws-cloudwatch-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_azure_integration.md
+++ b/docs/resources/betteruptime_azure_integration.md
@@ -26,7 +26,7 @@ https://betterstack.com/docs/uptime/api/azure-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_datadog_integration.md
+++ b/docs/resources/betteruptime_datadog_integration.md
@@ -27,7 +27,7 @@ https://betterstack.com/docs/uptime/api/datadog-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_elastic_integration.md
+++ b/docs/resources/betteruptime_elastic_integration.md
@@ -26,7 +26,7 @@ https://betterstack.com/docs/uptime/api/elastic-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_email_integration.md
+++ b/docs/resources/betteruptime_email_integration.md
@@ -42,7 +42,7 @@ https://betterstack.com/docs/uptime/api/email-integrations/
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `started_alert_id_field` (Block List, Max: 1) When starting an incident, how to extract an alert id, a unique alert identifier which will be used to acknowledge and resolve incidents. (see [below for nested schema](#nestedblock--started_alert_id_field))
 - `started_rules` (Block List) An array of rules to match to start a new incident. (see [below for nested schema](#nestedblock--started_rules))
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team.
 - `title_field` (Block List, Max: 1) An optional field describing how to extract a customized incident title. (see [below for nested schema](#nestedblock--title_field))
 

--- a/docs/resources/betteruptime_google_monitoring_integration.md
+++ b/docs/resources/betteruptime_google_monitoring_integration.md
@@ -26,7 +26,7 @@ https://betterstack.com/docs/uptime/api/google-monitoring-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_grafana_integration.md
+++ b/docs/resources/betteruptime_grafana_integration.md
@@ -26,7 +26,7 @@ https://betterstack.com/docs/uptime/api/grafana-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_heartbeat.md
+++ b/docs/resources/betteruptime_heartbeat.md
@@ -37,7 +37,7 @@ https://betterstack.com/docs/uptime/api/heartbeats/
 - `server_timezone` (String) The IANA timezone (e.g. "Europe/Berlin") used to evaluate this heartbeat's period against wall-clock time, keeping daily and cron-style schedules aligned across daylight saving time changes. Only applies to periods of 1 hour or longer; it is cleared for shorter periods.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `sort_index` (Number) An index controlling the position of a heartbeat in the heartbeat group.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team.
 
 ### Read-Only

--- a/docs/resources/betteruptime_heartbeat_group.md
+++ b/docs/resources/betteruptime_heartbeat_group.md
@@ -23,7 +23,7 @@ https://betterstack.com/docs/uptime/api/heartbeat-groups/
 
 - `paused` (Boolean) Set to true to pause monitoring for any existing heartbeats in the group - we won't notify you about downtime. Set to false to resume monitoring for any existing heartbeats in the group.
 - `sort_index` (Number) Set sort_index to specify how to sort your heartbeat groups.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_incoming_webhook.md
+++ b/docs/resources/betteruptime_incoming_webhook.md
@@ -42,7 +42,7 @@ https://betterstack.com/docs/uptime/api/list-all-incoming-webhooks/
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `started_alert_id_field` (Block List, Max: 1) When starting an incident, how to extract an alert id, a unique alert identifier which will be used to acknowledge and resolve incidents. (see [below for nested schema](#nestedblock--started_alert_id_field))
 - `started_rules` (Block List) An array of rules to match to start a new incident. (see [below for nested schema](#nestedblock--started_rules))
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team.
 - `title_field` (Block List, Max: 1) An optional field describing how to extract a customized incident title. (see [below for nested schema](#nestedblock--title_field))
 

--- a/docs/resources/betteruptime_metadata.md
+++ b/docs/resources/betteruptime_metadata.md
@@ -24,7 +24,7 @@ https://betterstack.com/docs/uptime/api/metadata/
 ### Optional
 
 - `metadata_value` (Block List) An array of typed metadata values of this Metadata. (see [below for nested schema](#nestedblock--metadata_value))
-- `team_name` (String, Deprecated) Used to specify the team the resource should be created in when using global tokens. This field is deprecated, team name doesn't have to be specified for this resource anymore.
+- `team_name` (String, Deprecated) Used to specify the team the resource should be created in when using global tokens. This field is deprecated, team name doesn't have to be specified for this resource anymore. You can't update this value later.
 - `value` (String, Deprecated) The value of this Metadata. This field is deprecated, use repeatable block metadata_value to define values with types instead.
 
 ### Read-Only

--- a/docs/resources/betteruptime_monitor.md
+++ b/docs/resources/betteruptime_monitor.md
@@ -95,7 +95,7 @@ https://betterstack.com/docs/uptime/api/monitors/
 - `scenario_name` (String) For Playwright monitors, the scenario name identifying the monitor in the UI. For Playwright monitors, either `url` or `scenario_name` must be provided.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
 - `ssl_expiration` (Number) How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60. Set to -1 to disable SSL expiration check.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team. In seconds.
 - `url` (String) URL of your website or the host you want to ping (see monitor_type below). Required for all monitor types except Playwright. For Playwright monitors, either `url` or `scenario_name` must be provided.
 - `verify_ssl` (Boolean) Should we verify SSL certificate validity?

--- a/docs/resources/betteruptime_monitor_group.md
+++ b/docs/resources/betteruptime_monitor_group.md
@@ -23,7 +23,7 @@ https://betterstack.com/docs/uptime/api/monitor-groups/
 
 - `paused` (Boolean) Set to true to pause monitoring for any existing monitors in the group - we won't notify you about downtime. Set to false to resume monitoring for any existing monitors in the group.
 - `sort_index` (Number) Set sort_index to specify how to sort your monitor groups.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_new_relic_integration.md
+++ b/docs/resources/betteruptime_new_relic_integration.md
@@ -27,7 +27,7 @@ https://betterstack.com/docs/uptime/api/new-relic-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_on_call_calendar.md
+++ b/docs/resources/betteruptime_on_call_calendar.md
@@ -22,7 +22,7 @@ https://betterstack.com/docs/uptime/api/on-call-calendar/
 ### Optional
 
 - `on_call_rotation` (Block List, Max: 1) Configuration block for the on-call rotation schedule. Ignored when omitted - on-call can be controlled in Better Stack. (see [below for nested schema](#nestedblock--on_call_rotation))
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_outgoing_webhook.md
+++ b/docs/resources/betteruptime_outgoing_webhook.md
@@ -30,7 +30,7 @@ https://betterstack.com/docs/uptime/api/outgoing-webhook-integrations/
 - `on_incident_reopened` (Boolean) Whether to trigger webhook when incident is reopened. Only when `trigger_type=incident_change`.
 - `on_incident_resolved` (Boolean) Whether to trigger webhook when incident is resolved. Only when `trigger_type=incident_change`.
 - `on_incident_started` (Boolean) Whether to trigger webhook when incident starts. Only when `trigger_type=incident_change`.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_pagerduty_integration.md
+++ b/docs/resources/betteruptime_pagerduty_integration.md
@@ -24,7 +24,7 @@ https://betterstack.com/docs/uptime/api/pagerduty-integrations/
 
 - `name` (String) The name of the PagerDuty Integration.
 - `notify_alongside_primary_responder` (Boolean) Whether this integration should be notified alongside the primary responder when no escalation policy is configured. Defaults to `true`.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -25,7 +25,7 @@ https://betterstack.com/docs/uptime/api/policies/
 - `policy_group_id` (Number) Set this attribute if you want to add this policy to a policy group.
 - `repeat_count` (Number) How many times should the entire policy be repeated if no one acknowledges the incident.
 - `repeat_delay` (Number) How long in seconds to wait before each repetition.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_policy_group.md
+++ b/docs/resources/betteruptime_policy_group.md
@@ -22,7 +22,7 @@ https://betterstack.com/docs/uptime/api/policy-groups/
 ### Optional
 
 - `sort_index` (Number) Set sort_index to specify how to sort your policy groups.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_prometheus_integration.md
+++ b/docs/resources/betteruptime_prometheus_integration.md
@@ -26,7 +26,7 @@ https://betterstack.com/docs/uptime/api/prometheus-integrations/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `recovery_period` (Number) How long the alert must be up to automatically mark an incident as resolved. In seconds.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 - `team_wait` (Number) How long we wait before escalating the incident alert to the team. In seconds.
 
 ### Read-Only

--- a/docs/resources/betteruptime_severity.md
+++ b/docs/resources/betteruptime_severity.md
@@ -27,7 +27,7 @@ https://betterstack.com/docs/uptime/api/list-all-severities/
 - `push` (Boolean) Whether to send a push notification when a new incident is created.
 - `severity_group_id` (Number) Set this attribute if you want to add this severity to a severity group.
 - `sms` (Boolean) Whether to send an SMS when a new incident is created.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_severity_group.md
+++ b/docs/resources/betteruptime_severity_group.md
@@ -22,7 +22,7 @@ https://betterstack.com/docs/uptime/api/urgency-groups/
 ### Optional
 
 - `sort_index` (Number) Set sort_index to specify how to sort your severity groups.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_splunk_oncall_integration.md
+++ b/docs/resources/betteruptime_splunk_oncall_integration.md
@@ -23,7 +23,7 @@ https://betterstack.com/docs/uptime/api/splunk-on-call-integrations/
 
 - `name` (String) The name of the Splunk On-Call Integration.
 - `notify_alongside_primary_responder` (Boolean) Whether this integration should be notified alongside the primary responder when no escalation policy is configured. Defaults to `true`.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/docs/resources/betteruptime_status_page_group.md
+++ b/docs/resources/betteruptime_status_page_group.md
@@ -22,7 +22,7 @@ https://betterstack.com/docs/uptime/api/status-page-groups/
 ### Optional
 
 - `sort_index` (Number) Set sort_index to specify how to sort your status page groups.
-- `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
+- `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only
 

--- a/internal/provider/resource_aws_cloudwatch_integration.go
+++ b/internal/provider/resource_aws_cloudwatch_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var awsCloudWatchIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the AWS CloudWatch Integration.",
 		Type:        schema.TypeString,
@@ -103,7 +96,7 @@ func newAwsCloudWatchIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/aws-cloudwatch-integrations/",
 		Schema:        awsCloudWatchIntegrationSchema,
 	}

--- a/internal/provider/resource_azure_integration.go
+++ b/internal/provider/resource_azure_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var azureIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the Azure Integration.",
 		Type:        schema.TypeString,
@@ -103,7 +96,7 @@ func newAzureIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/azure-integrations/",
 		Schema:        azureIntegrationSchema,
 	}

--- a/internal/provider/resource_datadog_integration.go
+++ b/internal/provider/resource_datadog_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var datadogIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the Datadog Integration.",
 		Type:        schema.TypeString,
@@ -109,7 +102,7 @@ func newDatadogIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/datadog-integrations/",
 		Schema:        datadogIntegrationSchema,
 	}

--- a/internal/provider/resource_elastic_integration.go
+++ b/internal/provider/resource_elastic_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var elasticIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the Elastic Integration.",
 		Type:        schema.TypeString,
@@ -103,7 +96,7 @@ func newElasticIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/elastic-integrations/",
 		Schema:        elasticIntegrationSchema,
 	}

--- a/internal/provider/resource_email_integration.go
+++ b/internal/provider/resource_email_integration.go
@@ -11,15 +11,7 @@ import (
 )
 
 var emailIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this Email integration.",
 		Type:        schema.TypeString,
@@ -212,8 +204,9 @@ func newEmailIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/email-integrations/",
-		Schema:      emailIntegrationSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/email-integrations/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        emailIntegrationSchema,
 	}
 }
 

--- a/internal/provider/resource_google_monitoring_integration.go
+++ b/internal/provider/resource_google_monitoring_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var googleMonitoringIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the Google Monitoring Integration.",
 		Type:        schema.TypeString,
@@ -103,7 +96,7 @@ func newGoogleMonitoringIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/google-monitoring-integrations/",
 		Schema:        googleMonitoringIntegrationSchema,
 	}

--- a/internal/provider/resource_grafana_integration.go
+++ b/internal/provider/resource_grafana_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var grafanaIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the Grafana Integration.",
 		Type:        schema.TypeString,
@@ -103,7 +96,7 @@ func newGrafanaIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/grafana-integrations/",
 		Schema:        grafanaIntegrationSchema,
 	}

--- a/internal/provider/resource_heartbeat.go
+++ b/internal/provider/resource_heartbeat.go
@@ -11,15 +11,7 @@ import (
 )
 
 var heartbeatSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this heartbeat.",
 		Type:        schema.TypeString,
@@ -180,8 +172,9 @@ func newHeartbeatResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/heartbeats/",
-		Schema:      heartbeatSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/heartbeats/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        heartbeatSchema,
 	}
 }
 

--- a/internal/provider/resource_heartbeat_group.go
+++ b/internal/provider/resource_heartbeat_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var heartbeatGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this Monitor.",
 		Type:        schema.TypeString,
@@ -69,8 +61,9 @@ func newHeartbeatGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/heartbeat-groups/",
-		Schema:      heartbeatGroupSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/heartbeat-groups/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        heartbeatGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_incoming_webhook.go
+++ b/internal/provider/resource_incoming_webhook.go
@@ -11,15 +11,7 @@ import (
 )
 
 var incomingWebhookSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this incoming webhook.",
 		Type:        schema.TypeString,
@@ -230,8 +222,9 @@ func newIncomingWebhookResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/list-all-incoming-webhooks/",
-		Schema:      incomingWebhookSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/list-all-incoming-webhooks/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        incomingWebhookSchema,
 	}
 }
 

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -21,7 +22,7 @@ import (
 
 var metadataSchema = map[string]*schema.Schema{
 	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens. This field is deprecated, team name doesn't have to be specified for this resource anymore.",
+		Description: "Used to specify the team the resource should be created in when using global tokens. This field is deprecated, team name doesn't have to be specified for this resource anymore. You can't update this value later.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Default:     nil,
@@ -150,7 +151,7 @@ func newMetadataResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateMetadata,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateMetadata),
 		Description:   "https://betterstack.com/docs/uptime/api/metadata/",
 		Schema:        metadataSchema,
 	}

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -17,15 +18,7 @@ import (
 var monitorTypes = []string{"status", "expected_status_code", "keyword", "keyword_absence", "ping", "tcp", "udp", "smtp", "pop", "imap", "dns", "playwright"}
 var ipVersions = []string{"ipv4", "ipv6"}
 var monitorSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this Monitor.",
 		Type:        schema.TypeString,
@@ -447,7 +440,7 @@ func newMonitorResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateMonitor,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateMonitor),
 		Description:   "https://betterstack.com/docs/uptime/api/monitors/",
 		Schema:        monitorSchema,
 	}

--- a/internal/provider/resource_monitor_group.go
+++ b/internal/provider/resource_monitor_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var monitorGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this Monitor group.",
 		Type:        schema.TypeString,
@@ -69,8 +61,9 @@ func newMonitorGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/monitor-groups/",
-		Schema:      monitorGroupSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/monitor-groups/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        monitorGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_new_relic_integration.go
+++ b/internal/provider/resource_new_relic_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var newRelicIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the AWS CloudWatch Integration.",
 		Type:        schema.TypeString,
@@ -109,7 +102,7 @@ func newNewRelicIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/new-relic-integrations/",
 		Schema:        newRelicIntegrationSchema,
 	}

--- a/internal/provider/resource_on_call_calendar.go
+++ b/internal/provider/resource_on_call_calendar.go
@@ -15,15 +15,7 @@ import (
 )
 
 var onCallCalendarSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the on-call calendar.",
 		Type:        schema.TypeString,
@@ -139,8 +131,9 @@ func newOnCallCalendarResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema:      onCallCalendarSchema,
-		Description: "https://betterstack.com/docs/uptime/api/on-call-calendar/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        onCallCalendarSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/on-call-calendar/",
 	}
 }
 

--- a/internal/provider/resource_outgoing_webhook.go
+++ b/internal/provider/resource_outgoing_webhook.go
@@ -7,20 +7,13 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var outgoingWebhookSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the outgoing webhook.",
 		Type:        schema.TypeString,
@@ -202,7 +195,7 @@ func newOutgoingWebhookResource() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Description:   "https://betterstack.com/docs/uptime/api/outgoing-webhook-integrations/",
-		CustomizeDiff: validateOutgoingWebhook,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateOutgoingWebhook),
 		Schema:        outgoingWebhookSchema,
 	}
 }

--- a/internal/provider/resource_pagerduty_integration.go
+++ b/internal/provider/resource_pagerduty_integration.go
@@ -7,20 +7,13 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var pagerdutyIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the PagerDuty Integration.",
 		Type:        schema.TypeString,
@@ -61,7 +54,7 @@ func newPagerdutyIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/pagerduty-integrations/",
 		Schema:        pagerdutyIntegrationSchema,
 	}

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/mapstructure"
@@ -158,15 +159,7 @@ var policyStepSchema = map[string]*schema.Schema{
 }
 
 var policySchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this Policy.",
 		Type:        schema.TypeString,
@@ -219,7 +212,7 @@ func newPolicyResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validatePolicy,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validatePolicy),
 		Schema:        policySchema,
 		Description:   "https://betterstack.com/docs/uptime/api/policies/",
 	}

--- a/internal/provider/resource_policy_group.go
+++ b/internal/provider/resource_policy_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var policyGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this policy group.",
 		Type:        schema.TypeString,
@@ -63,8 +55,9 @@ func newPolicyGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/policy-groups/",
-		Schema:      policyGroupSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/policy-groups/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        policyGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_prometheus_integration.go
+++ b/internal/provider/resource_prometheus_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var prometheusIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the AWS CloudWatch Integration.",
 		Type:        schema.TypeString,
@@ -103,7 +96,7 @@ func newPrometheusIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/prometheus-integrations/",
 		Schema:        prometheusIntegrationSchema,
 	}

--- a/internal/provider/resource_severity.go
+++ b/internal/provider/resource_severity.go
@@ -11,15 +11,7 @@ import (
 )
 
 var severitySchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this Severity.",
 		Type:        schema.TypeString,
@@ -78,8 +70,9 @@ func newSeverityResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/list-all-severities/",
-		Schema:      severitySchema,
+		Description:   "https://betterstack.com/docs/uptime/api/list-all-severities/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        severitySchema,
 	}
 }
 

--- a/internal/provider/resource_severity_group.go
+++ b/internal/provider/resource_severity_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var severityGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this severity group.",
 		Type:        schema.TypeString,
@@ -63,8 +55,9 @@ func newSeverityGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/urgency-groups/",
-		Schema:      severityGroupSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/urgency-groups/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        severityGroupSchema,
 	}
 }
 

--- a/internal/provider/resource_splunk_on_call_integration.go
+++ b/internal/provider/resource_splunk_on_call_integration.go
@@ -7,19 +7,12 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 var splunkOnCallIntegrationSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of the Splunk On-Call Integration.",
 		Type:        schema.TypeString,
@@ -54,7 +47,7 @@ func newSplunkOnCallIntegrationResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		CustomizeDiff: validateRequestHeaders,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateRequestHeaders),
 		Description:   "https://betterstack.com/docs/uptime/api/splunk-on-call-integrations/",
 		Schema:        splunkOnCallIntegrationSchema,
 	}

--- a/internal/provider/resource_status_page_group.go
+++ b/internal/provider/resource_status_page_group.go
@@ -11,15 +11,7 @@ import (
 )
 
 var statusPageGroupSchema = map[string]*schema.Schema{
-	"team_name": {
-		Description: "Used to specify the team the resource should be created in when using global tokens.",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Default:     nil,
-		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-			return d.Id() != ""
-		},
-	},
+	"team_name": teamNameSchema(),
 	"id": {
 		Description: "The ID of this status page group.",
 		Type:        schema.TypeString,
@@ -63,8 +55,9 @@ func newStatusPageGroupResource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Description: "https://betterstack.com/docs/uptime/api/status-page-groups/",
-		Schema:      statusPageGroupSchema,
+		Description:   "https://betterstack.com/docs/uptime/api/status-page-groups/",
+		CustomizeDiff: validateTeamNameNotChanged,
+		Schema:        statusPageGroupSchema,
 	}
 }
 

--- a/internal/provider/team_name.go
+++ b/internal/provider/team_name.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// teamNameSchema returns the schema for the team_name attribute shared by every resource that can
+// be created in a specific team using a global API token. The value is only used when the resource
+// is created; afterwards any change is suppressed (see DiffSuppressFunc) and changing it to a
+// different non-empty value is rejected (see validateTeamNameNotChanged).
+func teamNameSchema() *schema.Schema {
+	return &schema.Schema{
+		Description: "Used to specify the team the resource should be created in when using global tokens. You can't update this value later.",
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     nil,
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return d.Id() != ""
+		},
+	}
+}
+
+// validateTeamNameNotChanged rejects changing team_name to a different, non-empty value after a
+// resource has been created. team_name only selects the team when the resource is created with a
+// global API token and is ignored afterwards, so silently dropping the change ("No changes") was
+// confusing. Clearing the value remains a silent no-op (the diff is suppressed in teamNameSchema).
+//
+// The change is detected from the raw config and state rather than HasChange, because the
+// DiffSuppressFunc removes team_name from the computed diff before CustomizeDiff runs.
+func validateTeamNameNotChanged(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if diff.Id() == "" {
+		// The resource is being created — team_name is honored.
+		return nil
+	}
+
+	config := diff.GetRawConfig()
+	if config.IsNull() || !config.IsKnown() {
+		return nil
+	}
+	newAttr := config.GetAttr("team_name")
+	if newAttr.IsNull() || !newAttr.IsKnown() {
+		return nil
+	}
+	newName := newAttr.AsString()
+	if newName == "" {
+		// Clearing team_name has no effect, so allow it (the diff is suppressed).
+		return nil
+	}
+
+	oldName := ""
+	if state := diff.GetRawState(); !state.IsNull() && state.IsKnown() {
+		if oldAttr := state.GetAttr("team_name"); !oldAttr.IsNull() && oldAttr.IsKnown() {
+			oldName = oldAttr.AsString()
+		}
+	}
+	if newName != oldName {
+		return fmt.Errorf("team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token")
+	}
+	return nil
+}

--- a/internal/provider/team_name.go
+++ b/internal/provider/team_name.go
@@ -57,7 +57,7 @@ func validateTeamNameNotChanged(ctx context.Context, diff *schema.ResourceDiff, 
 		}
 	}
 	if newName != oldName {
-		return fmt.Errorf("team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token")
+		return fmt.Errorf("team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token, you can safely remove it from your configuration now")
 	}
 	return nil
 }

--- a/internal/provider/team_name_test.go
+++ b/internal/provider/team_name_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestTeamNameCannotBeChangedAfterCreate verifies team_name handling after a resource exists:
+// clearing it is a silent no-op (no plan change), while changing it to a different, non-empty
+// value fails with a helpful error. team_name is only used when creating a resource with a
+// global token.
+func TestTeamNameCannotBeChangedAfterCreate(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/urgency-groups", "1")
+	defer server.Close()
+
+	withTeamName := func(teamName string) string {
+		return fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_severity_group" "this" {
+					name       = "example"
+					sort_index = 1
+					team_name  = "%s"
+				}
+				`, teamName)
+	}
+	withoutTeamName := `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_severity_group" "this" {
+					name       = "example"
+					sort_index = 1
+				}
+				`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create in a team.
+			{
+				Config: withTeamName("First team"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_severity_group.this", "team_name", "First team"),
+				),
+			},
+			// Step 2 - clearing team_name is a no-op: no plan change, no error.
+			{
+				Config:   withoutTeamName,
+				PlanOnly: true,
+			},
+			// Step 3 - changing team_name to a different team must fail.
+			{
+				Config:      withTeamName("Second team"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`team_name cannot be changed after resource is created`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem

`team_name` is only used to pick the team when a resource is **created** with a global API token. Afterwards it is ignored, but a `DiffSuppressFunc` suppressed any diff on it once the resource existed — so changing `team_name` on an existing resource produced `No changes` with no explanation. Users had no way to tell the attribute was being silently ignored.

## Fix

- Replace the per-resource `DiffSuppressFunc` on `team_name` with a single shared `validateTeamNameNotChanged` `CustomizeDiff` that returns a clear error when `team_name` is changed to a non-empty value after the resource was created:

  > team_name cannot be changed after resource is created - it's only used to specify the team when creating it using a global token

  Removing `team_name` after creation stays a silent no-op (it has no effect either way).
- Define the attribute through a shared `teamNameSchema()` helper so every resource is consistent, and add "You can't update this value later." to its description.
- Regenerate docs with `make gen`.

Applied consistently to every resource that supports the create-only `team_name`.

## Out of scope

- `betteruptime_team_member.team_name` uses `ForceNew` (changing it recreates the membership in the new team), which is intentional behavior, so it is left unchanged.
- `betteruptime_slack_integration` is a data source, not a resource.

## Test

Adds `TestTeamNameCannotBeChangedAfterCreate`: creates a resource with a `team_name`, then asserts that changing it to a different value fails the plan with the new error.

Same as https://github.com/BetterStackHQ/terraform-provider-logtail/pull/86