### PR TITLE
[U-7151] Add fallback_policy_id to betteruptime_policy

### DIFF
--- a/docs/data-sources/betteruptime_policy.md
+++ b/docs/data-sources/betteruptime_policy.md
@@ -21,6 +21,7 @@ Policy lookup.
 
 ### Read-Only
 
+- `fallback_policy_id` (Number) Set this to escalate to another escalation policy once this policy has run all its steps and repeats without being acknowledged. The fallback policy must belong to the same organization.
 - `id` (String) The ID of this Policy.
 - `incident_token` (String) Incident token that can be used for manually reporting incidents.
 - `policy_group_id` (Number) Set this attribute if you want to add this policy to a policy group.

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -22,6 +22,7 @@ https://betterstack.com/docs/uptime/api/policies/
 
 ### Optional
 
+- `fallback_policy_id` (Number) Set this to escalate to another escalation policy once this policy has run all its steps and repeats without being acknowledged. The fallback policy must belong to the same organization.
 - `policy_group_id` (Number) Set this attribute if you want to add this policy to a policy group.
 - `repeat_count` (Number) How many times should the entire policy be repeated if no one acknowledges the incident.
 - `repeat_delay` (Number) How long in seconds to wait before each repetition.

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -421,6 +421,11 @@ resource "betteruptime_policy" "this" {
   repeat_delay    = 60
   policy_group_id = betteruptime_policy_group.this.id
 
+  # After all steps and the 3 repeats (every 60s) pass unacknowledged, escalation
+  # continues with the fallback policy below instead of stopping — the supported way
+  # to keep re-notifying once a policy is exhausted, without escalation loops.
+  fallback_policy_id = betteruptime_policy.fallback.id
+
   steps {
     type        = "escalation"
     wait_before = 0
@@ -491,6 +496,23 @@ EOT
   steps {
     type        = "escalation"
     wait_before = 180
+    urgency_id  = betteruptime_severity.this.id
+    step_members { type = "entire_team" }
+  }
+}
+
+# Fallback policy: invoked only after "this" exhausts its 3 repeats unacknowledged.
+# It repeats on its own cadence and widens the blast radius to the whole team —
+# illustrating how to chain repeated notifications across policies via fallback_policy_id.
+resource "betteruptime_policy" "fallback" {
+  name            = "Terraform Fallback Policy ${random_pet.unique.id}"
+  repeat_count    = 5
+  repeat_delay    = 120
+  policy_group_id = betteruptime_policy_group.this.id
+
+  steps {
+    type        = "escalation"
+    wait_before = 0
     urgency_id  = betteruptime_severity.this.id
     step_members { type = "entire_team" }
   }

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -183,6 +183,12 @@ var policySchema = map[string]*schema.Schema{
 		Optional:    true,
 		Computed:    true,
 	},
+	"fallback_policy_id": {
+		Description: "Set this to escalate to another escalation policy once this policy has run all its steps and repeats without being acknowledged. The fallback policy must belong to the same organization.",
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Computed:    true,
+	},
 	"incident_token": {
 		Description: "Incident token that can be used for manually reporting incidents.",
 		Type:        schema.TypeString,
@@ -247,14 +253,15 @@ type policyStep struct {
 }
 
 type policy struct {
-	Id            *int          `json:"id,omitempty"`
-	Name          *string       `json:"name,omitempty"`
-	RepeatCount   *int          `json:"repeat_count,omitempty"`
-	RepeatDelay   *int          `json:"repeat_delay,omitempty"`
-	IncidentToken *string       `json:"incident_token,omitempty"`
-	Steps         *[]policyStep `json:"steps"`
-	TeamName      *string       `json:"team_name,omitempty"`
-	PolicyGroupID *int          `json:"policy_group_id,omitempty"`
+	Id               *int          `json:"id,omitempty"`
+	Name             *string       `json:"name,omitempty"`
+	RepeatCount      *int          `json:"repeat_count,omitempty"`
+	RepeatDelay      *int          `json:"repeat_delay,omitempty"`
+	FallbackPolicyID *int          `json:"fallback_policy_id,omitempty"`
+	IncidentToken    *string       `json:"incident_token,omitempty"`
+	Steps            *[]policyStep `json:"steps"`
+	TeamName         *string       `json:"team_name,omitempty"`
+	PolicyGroupID    *int          `json:"policy_group_id,omitempty"`
 }
 
 type policyHTTPResponse struct {
@@ -276,6 +283,7 @@ func policyRef(in *policy) []struct {
 		{k: "name", v: &in.Name},
 		{k: "repeat_count", v: &in.RepeatCount},
 		{k: "repeat_delay", v: &in.RepeatDelay},
+		{k: "fallback_policy_id", v: &in.FallbackPolicyID},
 		{k: "incident_token", v: &in.IncidentToken},
 		{k: "steps", v: &in.Steps},
 		{k: "policy_group_id", v: &in.PolicyGroupID},

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -33,6 +33,7 @@ func TestResourcePolicy(t *testing.T) {
 				  name         = "Terraform - Test"
 				  repeat_count = 3
 				  repeat_delay = 60
+				  fallback_policy_id = 456
 
 				  steps {
 					type        = "escalation"
@@ -62,6 +63,7 @@ func TestResourcePolicy(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_policy.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "name", "Terraform - Test"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "fallback_policy_id", "456"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.urgency_id", "123"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.urgency_id", "123"),
 					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.step_members.0.type", "current_on_call"),


### PR DESCRIPTION
Expose the new escalation-policy fallback ("then escalate to") on the betteruptime_policy resource and data source: an optional, nullable integer pointing at another policy in the same organization. The data source derives it from policySchema automatically. Docs regenerated via tfplugindocs.