### PR TITLE
[U-8835] Add match_mode to betteruptime_catalog_relation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.20.19
+VERSION := 0.21.2
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_catalog_relation.md
+++ b/docs/resources/betteruptime_catalog_relation.md
@@ -22,6 +22,7 @@ https://betterstack.com/docs/uptime/api/catalog-integrations-relations/
 ### Optional
 
 - `description` (String) A description of the Catalog relation.
+- `match_mode` (String) Should a record enrich incidents matching any of its primary attribute values, or only incidents matching all of them (an empty primary value then matches any value). Possible values: any, all. Defaults to any.
 
 ### Read-Only
 

--- a/examples/catalog/main.tf
+++ b/examples/catalog/main.tf
@@ -96,16 +96,16 @@ resource "betteruptime_catalog_attribute" "service_on_call_team" {
   name        = betteruptime_catalog_attribute.on_call_team_name.name
 }
 
-resource "betteruptime_catalog_record" "homepage" {
+# API Services incidents in Production -> Backend team
+resource "betteruptime_catalog_record" "api_production" {
   relation_id = betteruptime_catalog_relation.service.id
 
   attribute {
     attribute_id = betteruptime_catalog_attribute.affected_service.id
     type         = "String"
-    value        = "Homepage"
+    value        = "API Services"
   }
 
-  # Matches only incidents with Environment: Production (other records leave Environment empty, matching any environment)
   attribute {
     attribute_id = betteruptime_catalog_attribute.service_environment.id
     type         = "String"
@@ -119,34 +119,36 @@ resource "betteruptime_catalog_record" "homepage" {
   }
 }
 
-resource "betteruptime_catalog_record" "api" {
+# Incidents from any service in Production -> Demo team (empty Affected service matches any value)
+resource "betteruptime_catalog_record" "any_service_production" {
   relation_id = betteruptime_catalog_relation.service.id
 
   attribute {
-    attribute_id = betteruptime_catalog_attribute.affected_service.id
+    attribute_id = betteruptime_catalog_attribute.service_environment.id
     type         = "String"
-    value        = "API Services"
-  }
-
-  attribute {
-    attribute_id = betteruptime_catalog_attribute.service_on_call_team.id
-    type         = "String"
-    value        = "Backend team"
-  }
-}
-
-resource "betteruptime_catalog_record" "landing_page" {
-  relation_id = betteruptime_catalog_relation.service.id
-
-  attribute {
-    attribute_id = betteruptime_catalog_attribute.affected_service.id
-    type         = "String"
-    value        = "Landing page"
+    value        = "Production"
   }
 
   attribute {
     attribute_id = betteruptime_catalog_attribute.service_on_call_team.id
     type         = "String"
     value        = "Demo team"
+  }
+}
+
+# Payment service incidents in any environment -> Backend team (empty Environment matches any value)
+resource "betteruptime_catalog_record" "payment_service" {
+  relation_id = betteruptime_catalog_relation.service.id
+
+  attribute {
+    attribute_id = betteruptime_catalog_attribute.affected_service.id
+    type         = "String"
+    value        = "Payment service"
+  }
+
+  attribute {
+    attribute_id = betteruptime_catalog_attribute.service_on_call_team.id
+    type         = "String"
+    value        = "Backend team"
   }
 }

--- a/examples/catalog/main.tf
+++ b/examples/catalog/main.tf
@@ -74,11 +74,19 @@ resource "betteruptime_catalog_record" "backend_team" {
 resource "betteruptime_catalog_relation" "service" {
   name        = "Service"
   description = "Services with responsible teams"
+  # Records enrich only incidents matching all primary attribute values; an empty primary value matches any value
+  match_mode = "all"
 }
 
 resource "betteruptime_catalog_attribute" "affected_service" {
   relation_id = betteruptime_catalog_relation.service.id
   name        = "Affected service"
+  primary     = true
+}
+
+resource "betteruptime_catalog_attribute" "service_environment" {
+  relation_id = betteruptime_catalog_relation.service.id
+  name        = "Environment"
   primary     = true
 }
 
@@ -95,6 +103,13 @@ resource "betteruptime_catalog_record" "homepage" {
     attribute_id = betteruptime_catalog_attribute.affected_service.id
     type         = "String"
     value        = "Homepage"
+  }
+
+  # Matches only incidents with Environment: Production (other records leave Environment empty, matching any environment)
+  attribute {
+    attribute_id = betteruptime_catalog_attribute.service_environment.id
+    type         = "String"
+    value        = "Production"
   }
 
   attribute {

--- a/examples/catalog/versions.tf
+++ b/examples/catalog/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.18.1"
+      version = ">= 0.21.2"
     }
   }
 }

--- a/internal/provider/resource_catalog_relation.go
+++ b/internal/provider/resource_catalog_relation.go
@@ -31,7 +31,7 @@ var catalogRelationSchema = map[string]*schema.Schema{
 		Description:  "Should a record enrich incidents matching any of its primary attribute values, or only incidents matching all of them (an empty primary value then matches any value). Possible values: any, all. Defaults to any.",
 		Type:         schema.TypeString,
 		Optional:     true,
-		Computed:     true,
+		Default:      "any",
 		ValidateFunc: validation.StringInSlice([]string{"any", "all"}, false),
 	},
 }

--- a/internal/provider/resource_catalog_relation.go
+++ b/internal/provider/resource_catalog_relation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 var catalogRelationSchema = map[string]*schema.Schema{
@@ -25,6 +26,13 @@ var catalogRelationSchema = map[string]*schema.Schema{
 		Description: "A description of the Catalog relation.",
 		Type:        schema.TypeString,
 		Optional:    true,
+	},
+	"match_mode": {
+		Description:  "Should a record enrich incidents matching any of its primary attribute values, or only incidents matching all of them (an empty primary value then matches any value). Possible values: any, all. Defaults to any.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"any", "all"}, false),
 	},
 }
 
@@ -46,6 +54,7 @@ type catalogRelation struct {
 	ID          *string `json:"id,omitempty"`
 	Name        *string `json:"name,omitempty"`
 	Description *string `json:"description,omitempty"`
+	MatchMode   *string `json:"match_mode,omitempty"`
 }
 
 type catalogRelationHTTPResponse struct {
@@ -65,6 +74,7 @@ func catalogRelationRef(in *catalogRelation) []struct {
 	}{
 		{k: "name", v: &in.Name},
 		{k: "description", v: &in.Description},
+		{k: "match_mode", v: &in.MatchMode},
 	}
 }
 

--- a/internal/provider/resource_catalog_relation_test.go
+++ b/internal/provider/resource_catalog_relation_test.go
@@ -34,12 +34,14 @@ func TestResourceCatalogRelation(t *testing.T) {
 				resource "betteruptime_catalog_relation" "this" {
 					name        = "%s"
 					description = "%s"
+					match_mode  = "any"
 				}
 				`, name, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_catalog_relation.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "name", name),
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "description", description),
+					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "match_mode", "any"),
 				),
 			},
 			// Step 2 - update
@@ -52,12 +54,14 @@ func TestResourceCatalogRelation(t *testing.T) {
 				resource "betteruptime_catalog_relation" "this" {
 					name        = "%s"
 					description = "%s"
+					match_mode  = "all"
 				}
 				`, name, updatedDescription),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_catalog_relation.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "name", name),
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "description", updatedDescription),
+					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "match_mode", "all"),
 				),
 			},
 			// Step 3 - make no changes, check plan is empty
@@ -70,6 +74,7 @@ func TestResourceCatalogRelation(t *testing.T) {
 				resource "betteruptime_catalog_relation" "this" {
 					name        = "%s"
 					description = "%s"
+					match_mode  = "all"
 				}
 				`, name, updatedDescription),
 				PlanOnly: true,

--- a/internal/provider/resource_catalog_relation_test.go
+++ b/internal/provider/resource_catalog_relation_test.go
@@ -34,13 +34,13 @@ func TestResourceCatalogRelation(t *testing.T) {
 				resource "betteruptime_catalog_relation" "this" {
 					name        = "%s"
 					description = "%s"
-					match_mode  = "any"
 				}
 				`, name, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("betteruptime_catalog_relation.this", "id"),
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "name", name),
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "description", description),
+					// match_mode defaults to "any" when omitted
 					resource.TestCheckResourceAttr("betteruptime_catalog_relation.this", "match_mode", "any"),
 				),
 			},


### PR DESCRIPTION
Mirrors the new catalog relations API argument. The catalog example now demonstrates match-all combination matching with an empty-primary (match any) record. Bumps VERSION/example constraint to 0.21.2 per the versioning guidance.