### PR TITLE
[U-4500] Allow creating betteruptime_policy with no steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.2
+VERSION := 0.21.3
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_policy.md
+++ b/docs/data-sources/betteruptime_policy.md
@@ -27,7 +27,7 @@ Policy lookup.
 - `policy_group_id` (Number) Set this attribute if you want to add this policy to a policy group.
 - `repeat_count` (Number) How many times should the entire policy be repeated if no one acknowledges the incident.
 - `repeat_delay` (Number) How long in seconds to wait before each repetition.
-- `steps` (List of Object) An array of escalation policy steps (see [below for nested schema](#nestedatt--steps))
+- `steps` (List of Object) An array of escalation policy steps. May be empty to create a silent policy that only collects incidents without alerting anyone. (see [below for nested schema](#nestedatt--steps))
 
 <a id="nestedatt--steps"></a>
 ### Nested Schema for `steps`

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -18,7 +18,6 @@ https://betterstack.com/docs/uptime/api/policies/
 ### Required
 
 - `name` (String) The name of this Policy.
-- `steps` (Block List, Min: 1) An array of escalation policy steps (see [below for nested schema](#nestedblock--steps))
 
 ### Optional
 
@@ -26,6 +25,7 @@ https://betterstack.com/docs/uptime/api/policies/
 - `policy_group_id` (Number) Set this attribute if you want to add this policy to a policy group.
 - `repeat_count` (Number) How many times should the entire policy be repeated if no one acknowledges the incident.
 - `repeat_delay` (Number) How long in seconds to wait before each repetition.
+- `steps` (Block List) An array of escalation policy steps. Omit it to create a policy with no steps (e.g. a silent policy that only collects incidents). (see [below for nested schema](#nestedblock--steps))
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -25,7 +25,7 @@ https://betterstack.com/docs/uptime/api/policies/
 - `policy_group_id` (Number) Set this attribute if you want to add this policy to a policy group.
 - `repeat_count` (Number) How many times should the entire policy be repeated if no one acknowledges the incident.
 - `repeat_delay` (Number) How long in seconds to wait before each repetition.
-- `steps` (Block List) An array of escalation policy steps. Omit it to create a policy with no steps (e.g. a silent policy that only collects incidents). (see [below for nested schema](#nestedblock--steps))
+- `steps` (Block List) An array of escalation policy steps. May be empty to create a silent policy that only collects incidents without alerting anyone. (see [below for nested schema](#nestedblock--steps))
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens. You can't update this value later.
 
 ### Read-Only

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -518,9 +518,8 @@ resource "betteruptime_policy" "fallback" {
   }
 }
 
-# Silent policy: a policy with no steps. It never alerts anyone — incidents routed
-# to it are only collected, mirroring what you can build in the UI. The "steps"
-# block is optional, so omitting it entirely is the supported way to stay silent.
+# Silent policy: a policy with no steps. It never alerts anyone, incidents are
+# only collected. The "steps" block is optional, so omitting it stays silent.
 resource "betteruptime_policy" "silent" {
   name            = "Terraform Silent Policy ${random_pet.unique.id}"
   repeat_count    = 0

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -518,6 +518,16 @@ resource "betteruptime_policy" "fallback" {
   }
 }
 
+# Silent policy: a policy with no steps. It never alerts anyone — incidents routed
+# to it are only collected, mirroring what you can build in the UI. The "steps"
+# block is optional, so omitting it entirely is the supported way to stay silent.
+resource "betteruptime_policy" "silent" {
+  name            = "Terraform Silent Policy ${random_pet.unique.id}"
+  repeat_count    = 0
+  repeat_delay    = 0
+  policy_group_id = betteruptime_policy_group.this.id
+}
+
 resource "betteruptime_severity_group" "this" {
   name = "Severities from Terraform"
 }

--- a/examples/advanced/outputs.tf
+++ b/examples/advanced/outputs.tf
@@ -6,6 +6,10 @@ output "escalation_policy_id" {
   value = betteruptime_policy.this.id
 }
 
+output "silent_policy_id" {
+  value = betteruptime_policy.silent.id
+}
+
 output "betteruptime_email_integration_address" { value = betteruptime_email_integration.this.email_address }
 
 output "betteruptime_incoming_webhook_url" { value = betteruptime_incoming_webhook.this.url }

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.20.19"
+      version = ">= 0.21.3"
     }
   }
 }

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -196,10 +196,10 @@ var policySchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"steps": {
-		Description: "An array of escalation policy steps",
+		Description: "An array of escalation policy steps. Omit it to create a policy with no steps (e.g. a silent policy that only collects incidents).",
 		Type:        schema.TypeList,
 		Elem:        &schema.Resource{Schema: policyStepSchema},
-		Required:    true,
+		Optional:    true,
 	},
 	"policy_group_id": {
 		Description: "Set this attribute if you want to add this policy to a policy group.",

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -196,7 +196,7 @@ var policySchema = map[string]*schema.Schema{
 		Computed:    true,
 	},
 	"steps": {
-		Description: "An array of escalation policy steps. Omit it to create a policy with no steps (e.g. a silent policy that only collects incidents).",
+		Description: "An array of escalation policy steps. May be empty to create a silent policy that only collects incidents without alerting anyone.",
 		Type:        schema.TypeList,
 		Elem:        &schema.Resource{Schema: policyStepSchema},
 		Optional:    true,

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -661,6 +661,72 @@ EOT
 	})
 }
 
+func TestResourcePolicyWithoutSteps(t *testing.T) {
+	server := newResourceServer(t, "/api/v3/policies", "1")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create a silent policy with no steps.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "this" {
+				  name         = "Terraform - Silent"
+				  repeat_count = 0
+				  repeat_delay = 0
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_policy.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "name", "Terraform - Silent"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.#", "0"),
+				),
+				PreConfig: func() {
+					t.Log("step 1")
+				},
+			},
+			// Step 2 - add a step to the previously empty policy.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "this" {
+				  name         = "Terraform - Silent"
+				  repeat_count = 0
+				  repeat_delay = 0
+
+				  steps {
+					type        = "escalation"
+					wait_before = 0
+					urgency_id  = 123
+					step_members { type = "current_on_call" }
+				  }
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.#", "1"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.type", "escalation"),
+				),
+				PreConfig: func() {
+					t.Log("step 2")
+				},
+			},
+		},
+	})
+}
+
 func TestResourcePolicyChainedPolicyMember(t *testing.T) {
 	server := newResourceServer(t, "/api/v3/policies", "1")
 	defer server.Close()


### PR DESCRIPTION
The `steps` block on `betteruptime_policy` was `Required` (implicit `Min: 1`), so `terraform plan` failed with "At least 1 steps blocks are required" even though the API and the UI already let you create an empty policy.

### What changed
- `steps` is now `Optional`, so a policy can be created with no steps (a silent policy that only collects incidents).

### Details
- Added a `betteruptime_policy.silent` resource and a `silent_policy_id` output to the advanced example, so the empty case is exercised end to end.
- Added `TestResourcePolicyWithoutSteps` covering create-empty, then add-a-step.
- Regenerated docs for the resource and the data source (the data source derives its schema from `policySchema`).
- Bumped VERSION and the advanced example constraint to 0.21.3, per the versioning guidance.