### PR TITLE
[U-9002] Add a No value matcher to betteruptime_policy metadata branching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.4
+VERSION := 0.21.5
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -80,6 +80,8 @@ Optional:
   - `name` - can be used to reference other items like teams, policies, etc.
   
   **The reference types require the presence of at least one of the three fields: `item_id`, `name`, `email`.**
+  
+  Policy `metadata_branching` steps additionally accept `no_value`, which matches incidents whose metadata field is absent or blank.
 - `value` (String) Value when type is String.
 
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -493,6 +493,10 @@ EOT
     metadata_value {
       value = "Notice"
     }
+    metadata_value {
+      # Also match incidents whose Description metadata is absent or blank.
+      type = "no_value"
+    }
     policy_id = null
   }
   steps {

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.4"
+      version = ">= 0.21.5"
     }
   }
 }

--- a/internal/provider/resource_metadata.go
+++ b/internal/provider/resource_metadata.go
@@ -93,6 +93,21 @@ var metadataTypes = []string{
 
 const scalarMetadataTypesCount = 1
 
+// metadataNoValueType is the policy-only "No value" matcher: it matches incidents whose
+// metadata field is absent or blank. It is not a real catalog type, carries no value or
+// identifier fields, and is only accepted in policy metadata_branching steps.
+const metadataNoValueType = "no_value"
+
+// validateNoValueMatcher ensures the "No value" sentinel carries no other fields.
+func validateNoValueMatcher(attrMap map[string]interface{}, path string) error {
+	for _, field := range []string{"value", "item_id", "name", "email"} {
+		if v, ok := attrMap[field].(string); ok && v != "" {
+			return fmt.Errorf("%s: %s must not be set for the no_value matcher", path, field)
+		}
+	}
+	return nil
+}
+
 var metadataValueSchema = map[string]*schema.Schema{
 	"type": {
 		Description: "Value types can be grouped into 2 main categories:\n" +
@@ -418,6 +433,11 @@ func validateMetadataValueWithRawConfig(attrMap map[string]interface{}, rawConfi
 
 func validateMetadataValue(attrMap map[string]interface{}, path string) error {
 	attrType := attrMap["type"].(string)
+
+	// The "No value" matcher is a bare sentinel with no value or identifier fields.
+	if attrType == metadataNoValueType {
+		return validateNoValueMatcher(attrMap, path)
+	}
 
 	// Validation for String type
 	if attrType == "String" {

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -41,6 +41,26 @@ var policyStepMemberSchema = map[string]*schema.Schema{
 	},
 }
 
+// policyMetadataTypes extends the shared metadata value types with the policy-only "no_value"
+// matcher, which matches incidents whose metadata field is absent or blank.
+var policyMetadataTypes = append(append([]string{}, metadataTypes...), metadataNoValueType)
+
+// policyMetadataValueSchema is the shared metadata value schema with the "no_value" type allowed.
+// no_value is specific to policy metadata_branching, so it is not added to the base schema.
+var policyMetadataValueSchema = map[string]*schema.Schema{
+	"type": {
+		Description:  metadataValueSchema["type"].Description + "  \n  Policy `metadata_branching` steps additionally accept `no_value`, which matches incidents whose metadata field is absent or blank.\n",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Default:      "String",
+		ValidateFunc: validation.StringInSlice(policyMetadataTypes, false),
+	},
+	"value":   metadataValueSchema["value"],
+	"item_id": metadataValueSchema["item_id"],
+	"name":    metadataValueSchema["name"],
+	"email":   metadataValueSchema["email"],
+}
+
 var policyStepSchema = map[string]*schema.Schema{
 	"type": {
 		Description:  "The type of the step. Can be either escalation, time_branching, metadata_branching, or instructions.",
@@ -123,7 +143,7 @@ var policyStepSchema = map[string]*schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		Default:     nil,
-		Elem:        &schema.Resource{Schema: metadataValueSchema},
+		Elem:        &schema.Resource{Schema: policyMetadataValueSchema},
 	},
 	"policy_id": {
 		Description: "A policy to executed if the branching rule matches the time of an incident. Used when step type is time_branching or metadata_branching.",

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -932,6 +932,74 @@ func TestResourcePolicyMetadataValidation(t *testing.T) {
 			`,
 			expectError: nil,
 		},
+		{
+			name: "valid - metadata branching with a no_value matcher",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type = "metadata_branching"
+						metadata_key = "environment"
+						metadata_value {
+							type = "no_value"
+						}
+						policy_id = 123
+					}
+				}
+			`,
+			expectError: nil,
+		},
+		{
+			name: "valid - no_value matcher combined with a literal value",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type = "metadata_branching"
+						metadata_key = "environment"
+						metadata_value {
+							type = "String"
+							value = "production"
+						}
+						metadata_value {
+							type = "no_value"
+						}
+						policy_id = 123
+					}
+				}
+			`,
+			expectError: nil,
+		},
+		{
+			name: "invalid - no_value matcher with a value",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type = "metadata_branching"
+						metadata_key = "environment"
+						metadata_value {
+							type = "no_value"
+							value = "oops"
+						}
+						policy_id = 123
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0\.metadata_value\.0: value must not be set for the no_value matcher`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
A policy metadata_branching step can now match incidents whose metadata field is absent or blank via metadata_value { type = "no_value" }, mirroring the uptime v3 API. The sentinel is scoped to the policy resource (not the shared metadata value types) and carries no value or identifier fields. Adds validation, an advanced example, regenerated docs, unit coverage, and bumps VERSION to 0.21.5.