### PR TITLE
Guard data-source lookups against null name/url fields

### DIFF
--- a/internal/provider/data_incoming_webhook.go
+++ b/internal/provider/data_incoming_webhook.go
@@ -82,7 +82,7 @@ func incomingWebhookLookup(ctx context.Context, d *schema.ResourceData, meta int
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.Name == name {
+			if e.Attributes.Name != nil && *e.Attributes.Name == name {
 				if d.Id() != "" {
 					return diag.Errorf("There are multiple incoming webhooks with the same name: %s", name)
 				}

--- a/internal/provider/data_incoming_webhook_test.go
+++ b/internal/provider/data_incoming_webhook_test.go
@@ -10,6 +10,48 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func TestDataIncomingWebhookSkipsNullName(t *testing.T) {
+	// A webhook with a null name (e.g. an unnamed integration created elsewhere) must
+	// not panic the lookup - it should be skipped and the named target still found.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		if r.Method == http.MethodGet && r.RequestURI == "/api/v2/incoming-webhooks?page=1" {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name":null,"url":"https://uptime.betterstack.com/api/v1/incoming-webhook/abc"}},{"id":"2","attributes":{"name":"Named Webhook","url":"https://uptime.betterstack.com/api/v1/incoming-webhook/def"}}],"pagination":{"next":null}}`))
+			return
+		}
+		t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				data "betteruptime_incoming_webhook" "this" {
+					name = "Named Webhook"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "id", "2"),
+					resource.TestCheckResourceAttr("data.betteruptime_incoming_webhook.this", "name", "Named Webhook"),
+				),
+			},
+		},
+	})
+}
+
 func TestDataIncomingWebhook(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)

--- a/internal/provider/data_monitor.go
+++ b/internal/provider/data_monitor.go
@@ -81,7 +81,7 @@ func monitorLookup(ctx context.Context, d *schema.ResourceData, meta interface{}
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.URL == url {
+			if e.Attributes.URL != nil && *e.Attributes.URL == url {
 				if d.Id() != "" {
 					return diag.Errorf("duplicate")
 				}

--- a/internal/provider/data_monitor_test.go
+++ b/internal/provider/data_monitor_test.go
@@ -11,6 +11,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestDataMonitorSkipsNullURL(t *testing.T) {
+	// A monitor with a null url must be skipped, not panic the lookup.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		if r.Method == http.MethodGet && r.RequestURI == "/api/v2/monitors?page=1" {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"url":null,"monitor_type":"status"}},{"id":"2","attributes":{"url":"http://example.com","monitor_type":"status"}}],"pagination":{"next":null}}`))
+			return
+		}
+		t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) { return New(WithURL(server.URL)), nil },
+		},
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "betteruptime" {
+				api_token = "foo"
+			}
+			data "betteruptime_monitor" "this" {
+				url = "http://example.com"
+			}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.betteruptime_monitor.this", "id", "2"),
+				resource.TestCheckResourceAttr("data.betteruptime_monitor.this", "url", "http://example.com"),
+			),
+		}},
+	})
+}
+
 func TestDataMonitor(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)

--- a/internal/provider/data_on_call_calendar.go
+++ b/internal/provider/data_on_call_calendar.go
@@ -138,7 +138,7 @@ func onCallCalendarLookup(ctx context.Context, d *schema.ResourceData, meta inte
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.Name == calendarName {
+			if e.Attributes.Name != nil && *e.Attributes.Name == calendarName {
 				if d.Id() != "" {
 					return diag.Errorf("There are multiple on-call calendars with the same name: %s", calendarName)
 				}

--- a/internal/provider/data_on_call_calendar_test.go
+++ b/internal/provider/data_on_call_calendar_test.go
@@ -10,6 +10,45 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func TestOnCallCalendarDataSkipsNullName(t *testing.T) {
+	// An on-call calendar with a null name must be skipped, not panic the lookup.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		switch {
+		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/on-calls?page=1":
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name":null,"default_calendar":false},"relationships":{"on_call_users":{"data":[]}}},{"id":"2","attributes":{"name":"Secondary","default_calendar":false},"relationships":{"on_call_users":{"data":[]}}}],"included":[],"pagination":{"next":null}}`))
+		case r.Method == http.MethodGet && r.RequestURI == "/api/v2/on-calls/2/rotation":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+		}
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) { return New(WithURL(server.URL)), nil },
+		},
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "betteruptime" {
+				api_token = "foo"
+			}
+			data "betteruptime_on_call_calendar" "this" {
+				name = "Secondary"
+			}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "id", "2"),
+				resource.TestCheckResourceAttr("data.betteruptime_on_call_calendar.this", "name", "Secondary"),
+			),
+		}},
+	})
+}
+
 func TestOnCallCalendarData(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)

--- a/internal/provider/data_policy.go
+++ b/internal/provider/data_policy.go
@@ -79,7 +79,7 @@ func policyLookup(ctx context.Context, d *schema.ResourceData, meta interface{})
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.Name == name {
+			if e.Attributes.Name != nil && *e.Attributes.Name == name {
 				if d.Id() != "" {
 					return diag.Errorf("There are multiple policies with the same name: %s", name)
 				}

--- a/internal/provider/data_policy_test.go
+++ b/internal/provider/data_policy_test.go
@@ -10,6 +10,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func TestDataPolicySkipsNullName(t *testing.T) {
+	// A policy with a null name must be skipped, not panic the lookup.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		if r.Method == http.MethodGet && r.RequestURI == "/api/v3/policies?page=1" {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"name":null,"incident_token":"abc"}},{"id":"2","attributes":{"name":"Target Policy","incident_token":"def"}}],"pagination":{"next":null}}`))
+			return
+		}
+		t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) { return New(WithURL(server.URL)), nil },
+		},
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "betteruptime" {
+				api_token = "foo"
+			}
+			data "betteruptime_policy" "this" {
+				name = "Target Policy"
+			}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.betteruptime_policy.this", "id", "2"),
+				resource.TestCheckResourceAttr("data.betteruptime_policy.this", "name", "Target Policy"),
+			),
+		}},
+	})
+}
+
 func TestDataPolicy(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)

--- a/internal/provider/data_severity.go
+++ b/internal/provider/data_severity.go
@@ -79,7 +79,7 @@ func severityLookup(ctx context.Context, d *schema.ResourceData, meta interface{
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.Name == name {
+			if e.Attributes.Name != nil && *e.Attributes.Name == name {
 				if d.Id() != "" {
 					return diag.Errorf("There are multiple severities with the same name: %s", name)
 				}

--- a/internal/provider/data_severity_test.go
+++ b/internal/provider/data_severity_test.go
@@ -10,6 +10,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func TestDataSeveritySkipsNullName(t *testing.T) {
+	// A severity with a null name must be skipped, not panic the lookup.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		if r.Method == http.MethodGet && r.RequestURI == "/api/v2/urgencies?page=1" {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","type":"urgency","attributes":{"name":null}},{"id":"2","type":"urgency","attributes":{"name":"Target Severity"}}],"pagination":{"next":null}}`))
+			return
+		}
+		t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) { return New(WithURL(server.URL)), nil },
+		},
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "betteruptime" {
+				api_token = "foo"
+			}
+			data "betteruptime_severity" "this" {
+				name = "Target Severity"
+			}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.betteruptime_severity.this", "id", "2"),
+				resource.TestCheckResourceAttr("data.betteruptime_severity.this", "name", "Target Severity"),
+			),
+		}},
+	})
+}
+
 func TestDataSeverity(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)

--- a/internal/provider/data_slack_integration.go
+++ b/internal/provider/data_slack_integration.go
@@ -81,7 +81,7 @@ func slackIntegrationLookup(ctx context.Context, d *schema.ResourceData, meta in
 			return diag.FromErr(err)
 		}
 		for _, e := range res.Data {
-			if *e.Attributes.SlackChannelName == slackChannelName {
+			if e.Attributes.SlackChannelName != nil && *e.Attributes.SlackChannelName == slackChannelName {
 				if d.Id() != "" {
 					return diag.Errorf("There are multiple Slack integrations with the same slack_channel_name: %s", slackChannelName)
 				}

--- a/internal/provider/data_slack_integration_test.go
+++ b/internal/provider/data_slack_integration_test.go
@@ -10,6 +10,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func TestDataSlackIntegrationSkipsNullChannel(t *testing.T) {
+	// A Slack integration with a null channel name must be skipped, not panic the lookup.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer foo" {
+			t.Fatal("Not authorized: " + r.Header.Get("Authorization"))
+		}
+		if r.Method == http.MethodGet && r.RequestURI == "/api/v2/slack-integrations?page=1" {
+			_, _ = w.Write([]byte(`{"data":[{"id":"1","attributes":{"slack_channel_name":null,"slack_team_name":"Team1"}},{"id":"2","attributes":{"slack_channel_name":"#target","slack_team_name":"Team2"}}],"pagination":{"next":null}}`))
+			return
+		}
+		t.Fatal("Unexpected " + r.Method + " " + r.RequestURI)
+	}))
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) { return New(WithURL(server.URL)), nil },
+		},
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "betteruptime" {
+				api_token = "foo"
+			}
+			data "betteruptime_slack_integration" "this" {
+				slack_channel_name = "#target"
+			}
+			`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("data.betteruptime_slack_integration.this", "id", "2"),
+				resource.TestCheckResourceAttr("data.betteruptime_slack_integration.this", "slack_channel_name", "#target"),
+			),
+		}},
+	})
+}
+
 func TestDataSlackIntegration(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Log("Received " + r.Method + " " + r.RequestURI)


### PR DESCRIPTION
found during #214 

## Problem
The list-based data sources (`betteruptime_incoming_webhook`, `monitor`, `policy`, `severity`, `on_call_calendar`, `slack_integration`) dereference the lookup field directly — `*e.Attributes.Name == name` (or `.URL` / `.SlackChannelName`) — with no nil check. Any record in the account with a null name/url (e.g. an unnamed incoming webhook) panics the provider with a nil-pointer dereference (SIGSEGV) during the data-source read.

## Fix
Guard each comparison with a nil check, matching the existing `data_role` pattern (`if e.Attributes.Name != nil && *e.Attributes.Name == name`), and add a null-field regression test for each of the six data sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)