### PR TITLE
Validate email/incoming-webhook rule conditions at plan time

### DIFF
--- a/internal/provider/integration_schemas.go
+++ b/internal/provider/integration_schemas.go
@@ -126,10 +126,7 @@ func isRulesAttribute(attribute string) bool  { return containsString(RulesAttri
 func isFieldAttribute(attribute string) bool  { return containsString(FieldAttributes, attribute) }
 func isFieldsAttribute(attribute string) bool { return containsString(FieldsAttributes, attribute) }
 
-// validateIntegrationRuleConditions rejects, at plan time, an email/incoming-webhook
-// integration whose *_rule_type is "all" or "any" but has no matching rules. The API
-// otherwise fails the apply with a 422 ("At least one condition ... is required").
-// "unused" matches every message and needs no rules, so it is always allowed.
+// "all" or "any" rule type requires at least 1 rule, otherwise the API call fails with 422
 func validateIntegrationRuleConditions(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
 	config := diff.GetRawConfig()
 	if config.IsNull() || !config.IsKnown() {

--- a/internal/provider/integration_schemas.go
+++ b/internal/provider/integration_schemas.go
@@ -1,6 +1,9 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/mapstructure"
@@ -122,6 +125,39 @@ func containsString(s []string, e string) bool {
 func isRulesAttribute(attribute string) bool  { return containsString(RulesAttributes, attribute) }
 func isFieldAttribute(attribute string) bool  { return containsString(FieldAttributes, attribute) }
 func isFieldsAttribute(attribute string) bool { return containsString(FieldsAttributes, attribute) }
+
+// validateIntegrationRuleConditions rejects, at plan time, an email/incoming-webhook
+// integration whose *_rule_type is "all" or "any" but has no matching rules. The API
+// otherwise fails the apply with a 422 ("At least one condition ... is required").
+// "unused" matches every message and needs no rules, so it is always allowed.
+func validateIntegrationRuleConditions(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	config := diff.GetRawConfig()
+	if config.IsNull() || !config.IsKnown() {
+		return nil
+	}
+	for _, pair := range []struct {
+		typeKey  string
+		rulesKey string
+	}{
+		{"started_rule_type", "started_rules"},
+		{"acknowledged_rule_type", "acknowledged_rules"},
+		{"resolved_rule_type", "resolved_rules"},
+	} {
+		typeAttr := config.GetAttr(pair.typeKey)
+		if typeAttr.IsNull() || !typeAttr.IsKnown() {
+			continue
+		}
+		ruleType := typeAttr.AsString()
+		if ruleType != "all" && ruleType != "any" {
+			continue
+		}
+		rulesAttr := config.GetAttr(pair.rulesKey)
+		if rulesAttr.IsNull() || (rulesAttr.IsKnown() && rulesAttr.LengthInt() == 0) {
+			return fmt.Errorf("%s = %q requires at least one %s block; use \"unused\" to match every message", pair.typeKey, ruleType, pair.rulesKey)
+		}
+	}
+	return nil
+}
 
 func loadIntegrationRules(d *schema.ResourceData, key string, receiver **[]integrationRule) {
 	x := receiver

--- a/internal/provider/resource_email_integration.go
+++ b/internal/provider/resource_email_integration.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -205,7 +206,7 @@ func newEmailIntegrationResource() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Description:   "https://betterstack.com/docs/uptime/api/email-integrations/",
-		CustomizeDiff: validateTeamNameNotChanged,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateIntegrationRuleConditions),
 		Schema:        emailIntegrationSchema,
 	}
 }

--- a/internal/provider/resource_email_integration_test.go
+++ b/internal/provider/resource_email_integration_test.go
@@ -1,11 +1,43 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
+
+func TestResourceEmailIntegrationRequiresStartCondition(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/email-integrations", "1")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// started_rule_type "all"/"any" requires at least one rule; "unused" matches every e-mail.
+			{
+				Config: `
+				provider "betteruptime" {
+				  api_token = "foo"
+				}
+
+				resource "betteruptime_email_integration" "this" {
+				  name                   = "Terraform Test"
+				  started_rule_type      = "all"
+				  acknowledged_rule_type = "unused"
+				  resolved_rule_type     = "unused"
+				}`,
+				ExpectError: regexp.MustCompile(`started_rule_type.*requires at least one`),
+			},
+		},
+	})
+}
 
 func TestResourceEmailIntegration(t *testing.T) {
 	server := newResourceServer(t, "/api/v2/email-integrations", "1")

--- a/internal/provider/resource_incoming_webhook.go
+++ b/internal/provider/resource_incoming_webhook.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -223,7 +224,7 @@ func newIncomingWebhookResource() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Description:   "https://betterstack.com/docs/uptime/api/list-all-incoming-webhooks/",
-		CustomizeDiff: validateTeamNameNotChanged,
+		CustomizeDiff: customdiff.Sequence(validateTeamNameNotChanged, validateIntegrationRuleConditions),
 		Schema:        incomingWebhookSchema,
 	}
 }

--- a/internal/provider/resource_incoming_webhook_test.go
+++ b/internal/provider/resource_incoming_webhook_test.go
@@ -8,6 +8,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+func TestResourceIncomingWebhookRequiresStartCondition(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/incoming-webhooks", "1")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// started_rule_type "all"/"any" requires at least one rule; "unused" matches every request.
+			{
+				Config: `
+				provider "betteruptime" {
+				  api_token = "foo"
+				}
+				resource "betteruptime_incoming_webhook" "this" {
+				  name                   = "Terraform Test"
+				  started_rule_type      = "all"
+				  acknowledged_rule_type = "unused"
+				  resolved_rule_type     = "unused"
+				}`,
+				ExpectError: regexp.MustCompile(`started_rule_type.*requires at least one`),
+			},
+		},
+	})
+}
+
 func TestResourceIncomingWebhook(t *testing.T) {
 	server := newResourceServer(t, "/api/v2/incoming-webhooks", "1")
 	defer server.Close()


### PR DESCRIPTION
found during #214 

## Problem
`betteruptime_email_integration` / `betteruptime_incoming_webhook` take a `*_rule_type` of `unused`, `any`, or `all`. When it's `any`/`all` the API requires at least one corresponding rule, and otherwise fails the **apply** with a 422 (`At least one condition ... is required`) — the user only finds out after `apply`.

## Fix
Add a plan-time `CustomizeDiff` (`validateIntegrationRuleConditions`) that rejects `all`/`any` with no rules up front, with a message pointing to `unused` (which matches every message). Wired into both resources via `customdiff.Sequence`; unit tests for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
