### PR TITLE
Fix content/content_before/content_after field descriptions

### DIFF
--- a/docs/resources/betteruptime_email_integration.md
+++ b/docs/resources/betteruptime_email_integration.md
@@ -58,9 +58,9 @@ https://betterstack.com/docs/uptime/api/email-integrations/
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -73,7 +73,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.
+- `content` (String) The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
@@ -84,9 +84,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -99,9 +99,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -114,9 +114,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -129,9 +129,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -144,9 +144,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -159,7 +159,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.
+- `content` (String) The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
@@ -170,9 +170,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -185,7 +185,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.
+- `content` (String) The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
@@ -196,9 +196,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.

--- a/docs/resources/betteruptime_incoming_webhook.md
+++ b/docs/resources/betteruptime_incoming_webhook.md
@@ -61,9 +61,9 @@ https://betterstack.com/docs/uptime/api/list-all-incoming-webhooks/
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -76,7 +76,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.
+- `content` (String) The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
@@ -87,9 +87,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -102,9 +102,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -117,9 +117,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -132,9 +132,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -147,9 +147,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -162,7 +162,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.
+- `content` (String) The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
@@ -173,9 +173,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.
@@ -188,7 +188,7 @@ Optional:
 
 Optional:
 
-- `content` (String) The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.
+- `content` (String) The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.
 - `match_type` (String) The type of the rule. Can be any of the following: contains, contains_not, matches_regex, matches_regex_not, equals, or equals_not.
 - `rule_target` (String) The target of the rule. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `target_field` (String) The target field within the content of the rule_target. Should be a JSON key when rule_target is json, a CSS selector when rule_target is XML, name of the header for headers or a parameter name for query parameters
@@ -199,9 +199,9 @@ Optional:
 
 Optional:
 
-- `content` (String) How should we extract content the field. Should be a valid Regex when match_type is match_regex.
-- `content_after` (String) When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.
-- `content_before` (String) When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.
+- `content` (String) The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.
+- `content_after` (String) When should we start extracting content for the field. Required when match_type is match_between.
+- `content_before` (String) When should we stop extracting content for the field. Required when match_type is match_between.
 - `field_target` (String) The target of the field. Can be any of the following: from_email, subject, or body for email integrations or query_string, header, body, json and xml for incoming webhooks.
 - `match_type` (String) The match type of the field. Can be any of the following: match_before, match_after, match_between, match_regex, or match_everything.
 - `name` (String) The name of the field.

--- a/internal/provider/integration_schemas.go
+++ b/internal/provider/integration_schemas.go
@@ -43,19 +43,19 @@ var integrationFieldSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{"match_before", "match_after", "match_between", "match_regex", "match_everything"}, false),
 	},
 	"content": {
-		Description: "How should we extract content the field. Should be a valid Regex when match_type is match_regex.",
+		Description: "The content to match. Required when match_type is match_before, match_after, or match_regex. Should be a valid regular expression when match_type is match_regex.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,
 	},
 	"content_before": {
-		Description: "When should we stop extracting content for the field. Should be present when match_type is either match_between or match_before.",
+		Description: "When should we stop extracting content for the field. Required when match_type is match_between.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,
 	},
 	"content_after": {
-		Description: "When should we start extracting content for the field. Should be present when match_type is either match_between or match_after.",
+		Description: "When should we start extracting content for the field. Required when match_type is match_between.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,
@@ -84,7 +84,7 @@ var integrationRuleSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{"contains", "contains_not", "matches_regex", "matches_regex_not", "equals", "equals_not"}, false),
 	},
 	"content": {
-		Description: "The content we should match to satisfy the rule. Should be a valid Regex when match_type is match_regex.",
+		Description: "The content we should match to satisfy the rule. Should be a valid regular expression when match_type is matches_regex.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,


### PR DESCRIPTION
found during https://github.com/BetterStackHQ/terraform-provider-better-uptime/pull/214

## Problem
The field extractor descriptions in the registry docs teach the wrong attribute: they say `content_after` "should be present when match_type is either match_between or **match_after**" (and `content_before` for `match_before`). The API actually requires the marker in **`content`** for `match_before`/`match_after`/`match_regex`; `content_before`/`content_after` are `match_between`-only (both `EmailField` and `IncomingWebhookField` validate exactly that). Following the docs yields a 422 (`content: is reserved`).

## Fix
Correct the three field descriptions and the rule `content` description (`matches_regex` is the rule enum; `match_regex` is fields-only). Docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
