### PR TITLE
U-5924 [status-page] Allow removing custom_domain with an empty string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.5
+VERSION := 0.21.6
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_status_page.md
+++ b/docs/resources/betteruptime_status_page.md
@@ -31,7 +31,7 @@ https://betterstack.com/docs/uptime/api/status-pages/
 - `automatic_reports` (Boolean) Generate automatic reports when your services go down
 - `contact_url` (String) URL that should be used for contacting you in case of an emergency.
 - `custom_css` (String) Unleash your inner designer and tweak our status page design to fit your branding.
-- `custom_domain` (String) Do you want a custom domain on your status page? Add a CNAME record that points your domain to status.betteruptime.com. Example: `CNAME status.walmine.com statuspage.betteruptime.com`
+- `custom_domain` (String) Do you want a custom domain on your status page? Add a CNAME record that points your domain to status.betteruptime.com. Example: `CNAME status.walmine.com statuspage.betteruptime.com` To remove the custom domain, set the value to an empty string `""`.
 - `custom_javascript` (String) Add custom behavior to your status page. It is only allowed for status pages with a custom domain name.
 - `dark_logo_url` (String) A direct link to a dark version of your company's logo. The image should be under 20MB in size.
 - `design` (String) Choose between classic and modern status page design. Possible values: 'v1', 'v2'.

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -50,6 +50,8 @@ resource "betteruptime_status_page" "this" {
   contact_url   = "mailto:support@example.com"
   timezone      = "Eastern Time (US & Canada)"
   subdomain     = coalesce(var.betteruptime_status_page_subdomain, random_id.status_page_subdomain.hex)
+  # Set to your own domain, e.g. "status.example.com" — setting it back to "" removes the custom domain again.
+  custom_domain = ""
   subscribable  = true
   ip_allowlist = [
     "# Office network",

--- a/examples/advanced/versions.tf
+++ b/examples/advanced/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.5"
+      version = ">= 0.21.6"
     }
   }
 }

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -76,7 +76,7 @@ var statusPageSchema = map[string]*schema.Schema{
 		Required:    true,
 	},
 	"custom_domain": {
-		Description: "Do you want a custom domain on your status page? Add a CNAME record that points your domain to status.betteruptime.com. Example: `CNAME status.walmine.com statuspage.betteruptime.com`",
+		Description: "Do you want a custom domain on your status page? Add a CNAME record that points your domain to status.betteruptime.com. Example: `CNAME status.walmine.com statuspage.betteruptime.com` To remove the custom domain, set the value to an empty string `\"\"`.",
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,
@@ -243,12 +243,35 @@ func newStatusPageResource() *schema.Resource {
 		ReadContext:   statusPageRead,
 		UpdateContext: statusPageUpdate,
 		DeleteContext: statusPageDelete,
+		CustomizeDiff: statusPageCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Description: "https://betterstack.com/docs/uptime/api/status-pages/",
 		Schema:      statusPageSchema,
 	}
+}
+
+// statusPageCustomizeDiff forces a diff for an explicit `custom_domain = ""`. The SDK treats an
+// empty string on an Optional+Computed attribute the same as an absent one and keeps the old
+// value, so the removal has to be detected from the raw config.
+func statusPageCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	if diff.Id() == "" {
+		// The resource is being created — there is no custom domain to remove yet.
+		return nil
+	}
+	config := diff.GetRawConfig()
+	if config.IsNull() || !config.IsKnown() {
+		return nil
+	}
+	attr := config.GetAttr("custom_domain")
+	if attr.IsNull() || !attr.IsKnown() || attr.AsString() != "" {
+		return nil
+	}
+	if old, _ := diff.GetChange("custom_domain"); old.(string) != "" {
+		return diff.SetNew("custom_domain", "")
+	}
+	return nil
 }
 
 type navigationLink struct {
@@ -424,17 +447,45 @@ func statusPageUpdate(ctx context.Context, d *schema.ResourceData, meta interfac
 			if d.HasChange(e.k) {
 				loadIPAllowlist(d, e.v.(**[]string))
 			}
+		} else if e.k == "custom_domain" {
+			loadCustomDomain(d, e.v.(**string))
 		} else {
 			if d.HasChange(e.k) {
 				load(d, e.k, e.v)
 			}
 		}
 	}
-	return resourceUpdate(ctx, meta, fmt.Sprintf("/api/v2/status-pages/%s", url.PathEscape(d.Id())), &in, &out)
+	if err := resourceUpdate(ctx, meta, fmt.Sprintf("/api/v2/status-pages/%s", url.PathEscape(d.Id())), &in, &out); err != nil {
+		return err
+	}
+	if in.CustomDomain != nil {
+		// The SDK plans a removed custom domain as "known after apply" and would keep the old
+		// value in state, so store the value that was sent to the API explicitly.
+		if err := d.Set("custom_domain", *in.CustomDomain); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return nil
 }
 
 func statusPageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return resourceDelete(ctx, meta, fmt.Sprintf("/api/v2/status-pages/%s", url.PathEscape(d.Id())))
+}
+
+// loadCustomDomain loads custom_domain including an explicit empty string, which both load()
+// and HasChange miss on a Computed attribute. The empty value has to reach the API to remove
+// the domain from the status page, so it's detected from the raw config instead.
+func loadCustomDomain(d *schema.ResourceData, target **string) {
+	if config := d.GetRawConfig(); !config.IsNull() && config.IsKnown() {
+		if attr := config.GetAttr("custom_domain"); !attr.IsNull() && attr.IsKnown() && attr.AsString() == "" {
+			t := ""
+			*target = &t
+			return
+		}
+	}
+	if d.HasChange("custom_domain") {
+		load(d, "custom_domain", target)
+	}
 }
 
 func loadNavigationLinks(d *schema.ResourceData, target **[]navigationLink) error {

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -255,7 +255,63 @@ func TestResourceStatusPage(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "require_sso", "false"),
 				),
 			},
-			// Step 8 - import.
+			// Step 8 - set custom domain.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page" "this" {
+					company_name  = "Example, Inc"
+					company_url   = "https://example.com"
+					timezone      = "America/Los_Angeles"
+					subdomain     = "%s"
+					custom_domain = "status.example.com"
+					navigation_links {
+						text = "Example2"
+						href = "https://example.com/test"
+					}
+					navigation_links {
+						text = "Status"
+						href = "/status"
+					}
+				}
+				`, subdomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_status_page.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_status_page.this", "custom_domain", "status.example.com"),
+				),
+			},
+			// Step 9 - remove custom domain using an empty string.
+			{
+				Config: fmt.Sprintf(`
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_status_page" "this" {
+					company_name  = "Example, Inc"
+					company_url   = "https://example.com"
+					timezone      = "America/Los_Angeles"
+					subdomain     = "%s"
+					custom_domain = ""
+					navigation_links {
+						text = "Example2"
+						href = "https://example.com/test"
+					}
+					navigation_links {
+						text = "Status"
+						href = "/status"
+					}
+				}
+				`, subdomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_status_page.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_status_page.this", "custom_domain", ""),
+				),
+			},
+			// Step 10 - import.
 			{
 				ResourceName:      "betteruptime_status_page.this",
 				ImportState:       true,


### PR DESCRIPTION
## Problem

Removing `custom_domain` from a `betteruptime_status_page` config produced no plan diff, so there was no way to unset a custom domain through Terraform (customer report in U-5924).

Two layers to it:
- `custom_domain` is `Optional` + `Computed`, and the SDK treats both an absent attribute and an explicit `""` as "keep the old value" — no diff is ever planned.
- Even with a diff, the update path loads values via `GetOkExists`, which skips empty strings, and `omitempty` then drops the nil pointer from the PATCH body entirely.

## Solution

Support the explicit empty string, consistent with how `password` and `ip_allowlist` handle unsetting:

- A `CustomizeDiff` detects `custom_domain = ""` in the raw config while state holds a domain, and forces the diff.
- `loadCustomDomain()` sends `"custom_domain": ""` in the PATCH — the API normalizes the empty string to no domain (verified in the uptime app: `custom_domain&.strip.presence` runs `before_validation`).
- After the update, the value is stored in state explicitly, because the SDK plans the removal as "known after apply" and would otherwise keep the old value.

Removing the attribute from config entirely remains a no-op — changing that would wipe domains for users who manage them outside Terraform, so the empty string is the explicit opt-in, now documented in the attribute description.

## Testing

- New unit test steps: set `custom_domain`, then remove it via `""` and verify the PATCH carries the empty value and state ends up cleared.
- `examples/advanced` now exercises `custom_domain = ""` (safe against the live API — an empty value at create is simply not sent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)