### PR TITLE
Add degraded_duration to status_history schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.6
+VERSION := 0.21.7
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_status_page_resource.md
+++ b/docs/resources/betteruptime_status_page_resource.md
@@ -199,6 +199,7 @@ Optional:
 Read-Only:
 
 - `day` (String)
+- `degraded_duration` (Number)
 - `downtime_duration` (Number)
 - `maintenance_duration` (Number)
 - `status` (String)

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -184,6 +184,12 @@ var statusPageStatusHistorySchema = map[string]*schema.Schema{
 		Optional:    true,
 		Computed:    true,
 	},
+	"degraded_duration": {
+		Description: "Status duration",
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Computed:    true,
+	},
 }
 
 func loadStatusPageResourceMetadataRule(d *schema.ResourceData, ruleKey string) *map[string]interface{} {


### PR DESCRIPTION
## Summary

`terraform plan` crashes during state refresh on `betteruptime_status_page_resource` with:

```
Error: Invalid address to set: []string{"status_history", "0", "degraded_duration"}
```

The `status_history` API attribute gained a new `degraded_duration` field, but it isn't declared in `statusPageStatusHistorySchema`, so the SDK rejects it while copying attributes from the API response into state. This is the same failure mode as #49, which added `maintenance_duration` for the same reason — this PR adds `degraded_duration` following that precedent.

Closes #222

## Changes

- Add `degraded_duration` to `statusPageStatusHistorySchema` in `internal/provider/resource_status_page_resource.go`, matching the existing `downtime_duration`/`maintenance_duration` fields.
- Regenerate `docs/resources/betteruptime_status_page_resource.md` via `make gen`.
- Bump `VERSION` in the `Makefile` to `0.21.7` per this repo's versioning convention.

`status_history` is a computed-only nested attribute (populated entirely by the API), so no example changes are needed — it's already exercised end-to-end by every existing `betteruptime_status_page_resource` example.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (passes)
- [x] `gofmt -l .` (clean)
- [x] `make gen` regenerated docs with no other diffs