### PR TITLE
U-9088 Ignore unknown API fields in status_history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.8
+VERSION := 0.21.9
 .PHONY: test build
 
 help:

--- a/internal/provider/ptr.go
+++ b/internal/provider/ptr.go
@@ -62,3 +62,22 @@ func truePtr() *bool {
 	b := true
 	return &b
 }
+
+// dropUnknownKeys removes keys not defined in the schema from raw API maps,
+// so fields newly added to the API are ignored instead of failing d.Set.
+func dropUnknownKeys(in *[]map[string]interface{}, s map[string]*schema.Schema) *[]map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make([]map[string]interface{}, len(*in))
+	for i, m := range *in {
+		filtered := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			if _, ok := s[k]; ok {
+				filtered[k] = v
+			}
+		}
+		out[i] = filtered
+	}
+	return &out
+}

--- a/internal/provider/resource_status_page_resource.go
+++ b/internal/provider/resource_status_page_resource.go
@@ -451,6 +451,7 @@ func statusPageResourceRead(ctx context.Context, d *schema.ResourceData, meta in
 
 func statusPageResourceCopyAttrs(d *schema.ResourceData, in *statusPageResource) diag.Diagnostics {
 	var derr diag.Diagnostics
+	in.StatusHistory = dropUnknownKeys(in.StatusHistory, statusPageStatusHistorySchema)
 	for _, e := range statusPageResourceRef(in) {
 		if e.k == "mark_as_down_metadata_rule" {
 			if err := statusPageResourceMetadataRuleCopyAttrs(d, in.MarkAsDownMetadataRule, "mark_as_down_metadata_rule"); err != nil {

--- a/internal/provider/resource_status_page_resource_test.go
+++ b/internal/provider/resource_status_page_resource_test.go
@@ -276,6 +276,59 @@ func TestResourceStatusPageResourceManuallyTrackedItem(t *testing.T) {
 	})
 }
 
+func TestResourceStatusPageResourceUnknownStatusHistoryField(t *testing.T) {
+	server := newResourceServer(t, "/api/v2/status-pages/0/resources", "1")
+	defer server.Close()
+
+	// The API returns status_history entries with fields unknown to the provider
+	// (e.g. degraded_duration, which caused https://github.com/BetterStackHQ/terraform-provider-better-uptime/issues/222).
+	attributes := `{"resource_id":2,"resource_type":"Monitor","public_name":"example","status_history":[{"day":"2026-07-08","status":"downtime","downtime_duration":60,"maintenance_duration":0,"degraded_duration":30,"another_future_field":"ignored"}]}`
+	server.ExpectRequest("POST", "/api/v2/status-pages/0/resources", "", 201, `{"data":{"id":"1","attributes":`+attributes+`}}`)
+	server.ExpectRequest("GET", "/api/v2/status-pages/0/resources/1", "", 200, `{"data":{"id":"1","attributes":`+attributes+`}}`)
+
+	config := `
+	provider "betteruptime" {
+		api_token = "foo"
+	}
+
+	resource "betteruptime_status_page_resource" "this" {
+		status_page_id = "0"
+		resource_id    = "2"
+		resource_type  = "Monitor"
+		public_name    = "example"
+	}
+	`
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create; unknown status_history fields must be ignored, known ones kept.
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_status_page_resource.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "status_history.#", "1"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "status_history.0.day", "2026-07-08"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "status_history.0.status", "downtime"),
+					resource.TestCheckResourceAttr("betteruptime_status_page_resource.this", "status_history.0.downtime_duration", "60"),
+					resource.TestCheckNoResourceAttr("betteruptime_status_page_resource.this", "status_history.0.degraded_duration"),
+					resource.TestCheckNoResourceAttr("betteruptime_status_page_resource.this", "status_history.0.another_future_field"),
+				),
+			},
+			// Step 2 - refresh + plan must not fail on the unknown fields either.
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestResourceStatusPageResourceValidation(t *testing.T) {
 	server := newResourceServer(t, "/api/v2/status-pages/0/resources", "1")
 	defer server.Close()


### PR DESCRIPTION
## Problem

Adding a field to the API's `status_history` objects broke every `terraform plan`/refresh touching a `betteruptime_status_page_resource` with `Invalid address to set: []string{"status_history", "0", "<new_field>"}` — twice already:

- #49 (`maintenance_duration`)
- #222 (`degraded_duration`)

Go's JSON decoding into structs already ignores unknown fields, so most of the provider is safe. The crash comes from `status_history` being decoded into raw `[]map[string]interface{}` and passed verbatim to `d.Set` against the fixed-key schema — any key the schema doesn't know fails the whole refresh.

## Fix

New `dropUnknownKeys` helper filters raw API maps against the schema before setting state, so the schema stays the single source of truth and fields newly added to the API are silently ignored instead of breaking the provider.

Audited all other resources: `status_history` was the only crash-class site here (the metadata rules are copied key-by-key, `jira_fields` is a JSON string, `request_headers` is a `TypeMap` accepting arbitrary keys). A sibling PR fixes the same pattern in the Telemetry provider's `logtail_connection.data_sources`.

## Test

`TestResourceStatusPageResourceUnknownStatusHistoryField` has the mock API return `status_history` entries with unknown fields (`degraded_duration`, `another_future_field`) on both create and refresh. Without the fix it fails with the exact error from #222; with it, known fields land in state and unknown ones are dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
