### PR TITLE
Bump version to 0.21.10 for status page published toggle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.9
+VERSION := 0.21.10
 .PHONY: test build
 
 help:

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.9"
+      version = ">= 0.21.10"
     }
   }
 }


### PR DESCRIPTION
v0.21.9 was tagged on #224 before #221 (status page `published` toggle) merged. Need to bump `Makefile` VERSION and the examples constraint to 0.21.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)