### PR TITLE
U-9147: Reject in-place playwright monitor_type changes and fix the refresh panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.10
+VERSION := 0.21.11
 .PHONY: test build
 
 help:

--- a/internal/provider/resource_monitor.go
+++ b/internal/provider/resource_monitor.go
@@ -620,16 +620,17 @@ func monitorCopyAttrs(d *schema.ResourceData, in *monitor) diag.Diagnostics {
 				derr = append(derr, diag.FromErr(err)[0])
 			}
 		} else if e.k == "url" {
-			// Special handling for URL and scenario name
+			// Special handling for URL and scenario name. The API omits either field for
+			// monitor types that don't have it, so keep the state value when it's absent.
 			currentUrl := d.Get("url").(string)
 			currentScenarioName := d.Get("scenario_name").(string)
-			if currentScenarioName != "" {
+			if currentScenarioName != "" && in.ScenarioName != nil {
 				// Read scenario name from API only if we have it defined
 				if err := d.Set("scenario_name", *in.ScenarioName); err != nil {
 					derr = append(derr, diag.FromErr(err)[0])
 				}
 			}
-			if currentUrl != "" || currentScenarioName == "" {
+			if (currentUrl != "" || currentScenarioName == "") && in.URL != nil {
 				// Read URL from API if we have it defined, or if we're missing scenario name
 				if err := d.Set("url", *in.URL); err != nil {
 					derr = append(derr, diag.FromErr(err)[0])
@@ -698,6 +699,17 @@ func validateMonitor(ctx context.Context, diff *schema.ResourceDiff, v interface
 	// Validate request headers
 	if err := validateRequestHeaders(ctx, diff, v); err != nil {
 		return err
+	}
+
+	// The API rejects in-place monitor_type changes to or from playwright (422), and the
+	// failed apply would still persist the planned attributes into state
+	// (hashicorp/terraform-plugin-sdk#476), leaving a state that panics on refresh - fail
+	// at plan time instead. Changes among the other types stay allowed in place.
+	if diff.Id() != "" && diff.HasChange("monitor_type") {
+		oldType, newType := diff.GetChange("monitor_type")
+		if oldType.(string) == "playwright" || newType.(string) == "playwright" {
+			return fmt.Errorf("monitor_type cannot be changed to or from 'playwright' in place; recreate the monitor instead, e.g. via terraform apply -replace")
+		}
 	}
 
 	// Validate URL requirement based on monitor type

--- a/internal/provider/resource_monitor_type_change_test.go
+++ b/internal/provider/resource_monitor_type_change_test.go
@@ -1,0 +1,155 @@
+package provider
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// The API omits scenario_name and url for monitor types that don't have them;
+// monitorCopyAttrs must not dereference the missing fields (issue #228: a refresh
+// after a failed in-place type change panicked with a nil dereference).
+func TestMonitorCopyAttrsNilOptionalFields(t *testing.T) {
+	t.Run("scenario_name in state, absent in API response", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, monitorSchema, map[string]interface{}{
+			"scenario_name": "httpbingo probe",
+			"monitor_type":  "keyword",
+		})
+		monitorType := "keyword"
+		monitorUrl := "https://example.com"
+		if derr := monitorCopyAttrs(d, &monitor{MonitorType: &monitorType, URL: &monitorUrl}); derr != nil {
+			t.Fatal(derr)
+		}
+		if got := d.Get("scenario_name").(string); got != "httpbingo probe" {
+			t.Fatalf("scenario_name = %q, want the state value preserved", got)
+		}
+	})
+
+	t.Run("url in state, absent in API response", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, monitorSchema, map[string]interface{}{
+			"url":          "https://example.com",
+			"monitor_type": "playwright",
+		})
+		monitorType := "playwright"
+		if derr := monitorCopyAttrs(d, &monitor{MonitorType: &monitorType}); derr != nil {
+			t.Fatal(derr)
+		}
+		if got := d.Get("url").(string); got != "https://example.com" {
+			t.Fatalf("url = %q, want the state value preserved", got)
+		}
+	})
+}
+
+func TestResourceMonitorTypeChangeToPlaywright(t *testing.T) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create a keyword monitor.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					url              = "https://example.com"
+					monitor_type     = "keyword"
+					required_keyword = "example"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", "keyword"),
+				),
+			},
+			// Step 2 - in-place changes within the non-playwright types stay allowed.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					url          = "https://example.com"
+					monitor_type = "status"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", "status"),
+				),
+			},
+			// Step 3 - changing to playwright must fail at plan time: the API rejects it
+			// and the failed apply would corrupt state (issue #228).
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type      = "playwright"
+					scenario_name     = "example probe"
+					playwright_script = "// script"
+				}
+				`,
+				ExpectError: regexp.MustCompile(`monitor_type cannot be changed to or from 'playwright'`),
+			},
+		},
+	})
+}
+
+func TestResourceMonitorTypeChangeFromPlaywright(t *testing.T) {
+	server := createTestServer(t)
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create a playwright monitor.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					monitor_type      = "playwright"
+					scenario_name     = "example probe"
+					playwright_script = "// script"
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_monitor.this", "monitor_type", "playwright"),
+				),
+			},
+			// Step 2 - changing away from playwright must fail at plan time.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_monitor" "this" {
+					url          = "https://example.com"
+					monitor_type = "status"
+				}
+				`,
+				ExpectError: regexp.MustCompile(`monitor_type cannot be changed to or from 'playwright'`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes BetterStackHQ/terraform-provider-better-uptime#228.

Changing `monitor_type` between `playwright` and the other types can't be applied in place — the API rejects it with a 422, Terraform persists the planned attributes anyway ([terraform-plugin-sdk#476](<https://github.com/hashicorp/terraform-plugin-sdk/issues/476>)), and the next refresh panicked on a nil dereference in `monitorCopyAttrs` (`scenario_name`/`url` present in state but absent from the API response).

Two changes:

* `monitorCopyAttrs` nil-checks `scenario_name` and `url` before dereferencing, keeping the state value when the API omits the field — refresh can no longer crash, whatever the state looks like.
* A plan-phase rule in `validateMonitor` rejects in-place `monitor_type` changes to or from `playwright` with a clear error suggesting `terraform apply -replace`. Changes among the other types (e.g. `keyword` → `status`) stay allowed in place, matching the API.

The first commit adds the failing tests (the panic repro fails at the exact line from the issue's stack trace); the second makes them pass.