### PR TITLE
Document that managing a billing admin needs a global API token

### DIFF
--- a/docs/data-sources/betteruptime_team_member.md
+++ b/docs/data-sources/betteruptime_team_member.md
@@ -45,7 +45,7 @@ output "existing_team_member_id" {
 - `last_name` (String) The last name of the team member (available after invitation is accepted).
 - `member_id` (String) The numeric ID of the team member. Empty for pending invitations.
 - `mobile_app_platforms` (List of String) The mobile app platforms the team member has installed (e.g. ios, android).
-- `role` (String) The system role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder. Use `role_id` to assign a custom role. Set only one of `role` or `role_id`.
+- `role` (String) The system role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder. Use `role_id` to assign a custom role. Set only one of `role` or `role_id`. Managing a team member whose role is `billing_admin` requires a global API token, because Billing admin applies to every team in the organization.
 - `role_id` (String) The ID of the role to assign — for example from the betteruptime_role data source. Use this to assign a custom role (for built-in roles you can use `role` instead). Set only one of `role` or `role_id`.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ provider "betteruptime" {
 
 ### Required
 
-- `api_token` (String, Sensitive) Better Stack Uptime API token. The value can be omitted if `BETTERUPTIME_API_TOKEN` environment variable is set. See https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/#obtaining-an-uptime-api-token on how to obtain the API token for your team.
+- `api_token` (String, Sensitive) Better Stack Uptime API token. The value can be omitted if `BETTERUPTIME_API_TOKEN` environment variable is set. See https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/#obtaining-an-uptime-api-token on how to obtain the API token for your team. Managing a `betteruptime_team_member` whose role is `billing_admin` requires a global API token rather than a team-scoped one.
 
 ### Optional
 

--- a/docs/resources/betteruptime_team_member.md
+++ b/docs/resources/betteruptime_team_member.md
@@ -47,7 +47,7 @@ resource "betteruptime_team_member" "dylan" {
 
 ### Optional
 
-- `role` (String) The system role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder. Use `role_id` to assign a custom role. Set only one of `role` or `role_id`.
+- `role` (String) The system role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder. Use `role_id` to assign a custom role. Set only one of `role` or `role_id`. Managing a team member whose role is `billing_admin` requires a global API token, because Billing admin applies to every team in the organization.
 - `role_id` (String) The ID of the role to assign — for example from the betteruptime_role data source. Use this to assign a custom role (for built-in roles you can use `role` instead). Set only one of `role` or `role_id`.
 - `team_name` (String) Used to specify the team the resource should be created in when using global tokens.
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -42,7 +42,7 @@ func New(opts ...Option) *schema.Provider {
 				Sensitive:   true,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("BETTERUPTIME_API_TOKEN", nil),
-				Description: "Better Stack Uptime API token. The value can be omitted if `BETTERUPTIME_API_TOKEN` environment variable is set. See https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/#obtaining-an-uptime-api-token on how to obtain the API token for your team.",
+				Description: "Better Stack Uptime API token. The value can be omitted if `BETTERUPTIME_API_TOKEN` environment variable is set. See https://betterstack.com/docs/uptime/api/getting-started-with-uptime-api/#obtaining-an-uptime-api-token on how to obtain the API token for your team. Managing a `betteruptime_team_member` whose role is `billing_admin` requires a global API token rather than a team-scoped one.",
 			},
 			"api_retry_max": {
 				Type:        schema.TypeInt,

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -30,7 +30,7 @@ var teamMemberSchema = map[string]*schema.Schema{
 		ForceNew:    true,
 	},
 	"role": {
-		Description:      "The system role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder. Use `role_id` to assign a custom role. Set only one of `role` or `role_id`.",
+		Description:      "The system role of the team member. Allowed values: responder, member, team_lead, billing_admin. Defaults to responder. Use `role_id` to assign a custom role. Set only one of `role` or `role_id`. Managing a team member whose role is `billing_admin` requires a global API token, because Billing admin applies to every team in the organization.",
 		Type:             schema.TypeString,
 		Optional:         true,
 		Computed:         true,


### PR DESCRIPTION
Documentation only. No behaviour change in the provider.

## Why

Better Stack (BetterStackHQ/betterstack#5823) now rejects a **team-scoped Uptime API token** on the team member endpoints whenever the operation involves the organization-wide **Billing admin** role. A team token carries no user identity, so the API cannot rank-check it against the role being assigned; a global token can only be minted by an organization Admin, which is the closest available proxy.

This provider is squarely affected. It authenticates every request with a single `api_token`, and its own documentation tells users to create a **team-scoped** token: "See ... on how to obtain the API token **for your team**" (`internal/provider/provider.go`), mirrored into `docs/index.md` and `README.md`. The repo's E2E workflow uses `secrets.UPTIME_E2E_TEAM_TOKEN`.

So for a `betteruptime_team_member` whose role is `billing_admin`, three paths start returning 403 with a team token: create/invite, change-role, and delete on `terraform destroy`.

## What changed

- `role` attribute description on `betteruptime_team_member` (resource and data source) now states the global-token requirement.
- Provider `api_token` description carries the same note, since that is where a user must act.
- Generated docs updated to match, so `go generate` produces no diff.

## Deliberately not changed

- **The `role` enum keeps `billing_admin`.** It remains valid with a global token.
- **The `DiffSuppressFunc` still only exempts `admin`.** Suppressing `billing_admin` would break legitimate global-token users who do want to change that role. Worth knowing though: a member who already holds `billing_admin`, adopted into a config naming a different role, produces a perpetual diff that now fails on every apply with a team token. That is a real rough edge, and arguably wants its own issue rather than a silent suppression.

## Migration note for users

Switching to a global token is not a one-line change. A global token that spans more than one team makes `team_name` mandatory, and `team_name` is rejected for team tokens, so it cannot be added defensively in advance across the resources that accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)