### PR TITLE
Bump version to 0.21.12 for the status page RSS feed setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.11
+VERSION := 0.21.12
 .PHONY: test build
 
 help:

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.10"
+      version = ">= 0.21.12"
     }
   }
 }


### PR DESCRIPTION
Release prep for **v0.21.12**, covering the two commits on `master` since `v0.21.11`:

- #231 — `include_all_incidents_in_rss_feed` on `betteruptime_status_page`
- #230 — billing admin docs

The matching uptime API change is deployed (production release `7882d23b`, 11:43 UTC), so the attribute is live server-side and the provider will round-trip it correctly.

### Note on `examples/versions.tf`

It jumps 0.21.10 → 0.21.12. #229 bumped the `Makefile` to 0.21.11 inside the feature PR without touching `versions.tf`, so the constraint shown to users has been one release behind since then. This catches it up rather than perpetuating the drift.

### After merge

Tag `v0.21.12` on `master` and push it — `release.yml` fires on `v*` and runs GoReleaser (GPG-signed, publishes the GitHub release the Terraform Registry picks up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)