### PR TITLE
U-9092 Support the resolve_remove policy step type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.13
+VERSION := 0.21.12
 .PHONY: test build
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.11
+VERSION := 0.21.13
 .PHONY: test build
 
 help:

--- a/docs/data-sources/betteruptime_policy.md
+++ b/docs/data-sources/betteruptime_policy.md
@@ -46,6 +46,7 @@ output "policy_id" {
 
 Read-Only:
 
+- `action_type` (String)
 - `comment` (String)
 - `days` (List of String)
 - `metadata_key` (String)

--- a/docs/resources/betteruptime_policy.md
+++ b/docs/resources/betteruptime_policy.md
@@ -183,6 +183,38 @@ resource "betteruptime_policy" "metadata_routing" {
   }
 }
 
+# Auto-triage policy: remove false positives right away, page whoever is on call,
+# then auto-resolve the incident if it is still open an hour later
+resource "betteruptime_policy" "auto_resolve" {
+  name            = "Terraform Auto Resolve Policy ${random_pet.unique.id}"
+  policy_group_id = betteruptime_policy_group.this.id
+
+  steps {
+    type         = "metadata_branching"
+    wait_before  = 0
+    metadata_key = "Description"
+    metadata_value {
+      value = "False positive"
+    }
+
+    # Remove matching incidents instead of escalating to a policy
+    action_type = "remove_incident"
+  }
+  steps {
+    type        = "escalation"
+    wait_before = 0
+    urgency_id  = data.betteruptime_severity.low.id
+    step_members { type = "current_on_call" }
+  }
+  steps {
+    type        = "resolve_remove"
+    wait_before = 3600
+
+    # Use "remove_incident" to remove the incident without a trace instead
+    action_type = "resolve_incident"
+  }
+}
+
 # Fallback policy: takes over once "this" exhausts its repeats unacknowledged,
 # widening the blast radius to the whole team
 resource "betteruptime_policy" "fallback" {
@@ -234,10 +266,11 @@ resource "betteruptime_policy" "silent" {
 
 Required:
 
-- `type` (String) The type of the step. Can be either escalation, time_branching, metadata_branching, or instructions.
+- `type` (String) The type of the step. Can be either escalation, time_branching, metadata_branching, instructions, or resolve_remove.
 
 Optional:
 
+- `action_type` (String) The action to take. Required when step type is resolve_remove - use resolve_incident or remove_incident. Optional when step type is time_branching or metadata_branching - use escalate_to_policy, resolve_incident, remove_incident, or do_not_escalate. When omitted on branching steps, the action defaults to escalate_to_policy if policy_id or policy_metadata_key is set, and to do_not_escalate otherwise; the resolved value is stored in state, so change it by setting an explicit value.
 - `comment` (String) Post instructions as a comment into the incident timeline. You can use Markdown, reference metadata as `{server_region}`, and interactive checkboxes like `- [ ] Step 1`. Used when step type is instructions.
 - `days` (List of String) An array of days during which the branching rule will be executed. Valid values are ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]. Used when step type is branching.
 - `metadata_key` (String) A metadata field key to check. Used when step type is metadata_branching.

--- a/examples/resources/betteruptime_policy/resource.tf
+++ b/examples/resources/betteruptime_policy/resource.tf
@@ -168,6 +168,38 @@ resource "betteruptime_policy" "metadata_routing" {
   }
 }
 
+# Auto-triage policy: remove false positives right away, page whoever is on call,
+# then auto-resolve the incident if it is still open an hour later
+resource "betteruptime_policy" "auto_resolve" {
+  name            = "Terraform Auto Resolve Policy ${random_pet.unique.id}"
+  policy_group_id = betteruptime_policy_group.this.id
+
+  steps {
+    type         = "metadata_branching"
+    wait_before  = 0
+    metadata_key = "Description"
+    metadata_value {
+      value = "False positive"
+    }
+
+    # Remove matching incidents instead of escalating to a policy
+    action_type = "remove_incident"
+  }
+  steps {
+    type        = "escalation"
+    wait_before = 0
+    urgency_id  = data.betteruptime_severity.low.id
+    step_members { type = "current_on_call" }
+  }
+  steps {
+    type        = "resolve_remove"
+    wait_before = 3600
+
+    # Use "remove_incident" to remove the incident without a trace instead
+    action_type = "resolve_incident"
+  }
+}
+
 # Fallback policy: takes over once "this" exhausts its repeats unacknowledged,
 # widening the blast radius to the whole team
 resource "betteruptime_policy" "fallback" {

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.13"
+      version = ">= 0.21.12"
     }
   }
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     betteruptime = {
       source  = "BetterStackHQ/better-uptime"
-      version = ">= 0.21.10"
+      version = ">= 0.21.13"
     }
   }
 }

--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -69,10 +69,10 @@ var policyMetadataValueSchema = map[string]*schema.Schema{
 
 var policyStepSchema = map[string]*schema.Schema{
 	"type": {
-		Description:  "The type of the step. Can be either escalation, time_branching, metadata_branching, or instructions.",
+		Description:  "The type of the step. Can be either escalation, time_branching, metadata_branching, instructions, or resolve_remove.",
 		Type:         schema.TypeString,
 		Required:     true,
-		ValidateFunc: validation.StringInSlice([]string{"escalation", "time_branching", "metadata_branching", "instructions"}, false),
+		ValidateFunc: validation.StringInSlice([]string{"escalation", "time_branching", "metadata_branching", "instructions", "resolve_remove"}, false),
 	},
 	"wait_before": {
 		Description: "How long to wait in seconds before executing this step since previous step. Omit if wait_until_time is set.",
@@ -150,6 +150,13 @@ var policyStepSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Default:     nil,
 		Elem:        &schema.Resource{Schema: policyMetadataValueSchema},
+	},
+	"action_type": {
+		Description:  "The action to take. Required when step type is resolve_remove - use resolve_incident or remove_incident. Optional when step type is time_branching or metadata_branching - use escalate_to_policy, resolve_incident, remove_incident, or do_not_escalate. When omitted on branching steps, the action defaults to escalate_to_policy if policy_id or policy_metadata_key is set, and to do_not_escalate otherwise; the resolved value is stored in state, so change it by setting an explicit value.",
+		Type:         schema.TypeString,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validation.StringInSlice([]string{"escalate_to_policy", "resolve_incident", "remove_incident", "do_not_escalate"}, false),
 	},
 	"policy_id": {
 		Description: "A policy to executed if the branching rule matches the time of an incident. Used when step type is time_branching or metadata_branching.",
@@ -272,6 +279,7 @@ type policyStep struct {
 	MetadataKey           *string             `mapstructure:"metadata_key,omitempty" json:"metadata_key,omitempty"`
 	MetadataValues        *[]metadataValue    `mapstructure:"metadata_value" json:"metadata_values,omitempty"`
 	LegacyMetadataValues  *[]string           `mapstructure:"metadata_values" json:"-"`
+	ActionType            *string             `mapstructure:"action_type,omitempty" json:"action_type,omitempty"`
 	PolicyId              *int                `mapstructure:"policy_id,omitempty" json:"policy_id,omitempty"`
 	PolicyMetadataKey     *string             `mapstructure:"policy_metadata_key,omitempty" json:"policy_metadata_key,omitempty"`
 	Comment               *string             `mapstructure:"comment,omitempty" json:"instructions_comment,omitempty"`
@@ -434,6 +442,11 @@ func loadPolicySteps(d *schema.ResourceData, receiver **[]policyStep) error {
 			stepValuesObject["reminder_interval_hours"] = nil
 		}
 
+		// Clear the computed action_type for step types that don't use it
+		if stepType == "escalation" || stepType == "instructions" {
+			stepValuesObject["action_type"] = nil
+		}
+
 		// Remove default values ("" or 0) from step
 		for k, v := range stepValuesObject {
 			if v == "" || v == 0 {
@@ -531,6 +544,32 @@ func validatePolicy(ctx context.Context, d *schema.ResourceDiff, m interface{}) 
 			if len(stepMap["metadata_value"].([]interface{})) > 0 {
 				return fmt.Errorf("steps.%d: metadata_value must be empty for non-metadata_branching steps", i)
 			}
+		}
+
+		// Validate action_type - it drives resolve_remove steps and the outcome of branching steps
+		actionType, _ := stepMap["action_type"].(string)
+		policyID, _ := stepMap["policy_id"].(int)
+		policyMetadataKey, _ := stepMap["policy_metadata_key"].(string)
+		if stepType == "resolve_remove" {
+			if actionType != "resolve_incident" && actionType != "remove_incident" {
+				return fmt.Errorf("steps.%d: action_type must be either resolve_incident or remove_incident for resolve_remove step", i)
+			}
+			if policyID != 0 || policyMetadataKey != "" {
+				return fmt.Errorf("steps.%d: policy_id and policy_metadata_key cannot be used with resolve_remove step", i)
+			}
+		} else if stepType == "time_branching" || stepType == "metadata_branching" {
+			// An unknown policy_id (a reference to a not-yet-created policy) reads as 0 during plan - only
+			// require a policy when both policy attributes are known to be empty.
+			policyKnown := d.NewValueKnown(fmt.Sprintf("steps.%d.policy_id", i)) && d.NewValueKnown(fmt.Sprintf("steps.%d.policy_metadata_key", i))
+			if actionType == "escalate_to_policy" && policyID == 0 && policyMetadataKey == "" && policyKnown {
+				return fmt.Errorf("steps.%d: policy_id or policy_metadata_key must be set when action_type is escalate_to_policy", i)
+			}
+			if actionType != "" && actionType != "escalate_to_policy" && (policyID != 0 || policyMetadataKey != "") {
+				return fmt.Errorf("steps.%d: policy_id and policy_metadata_key cannot be used when action_type is %s, set action_type = \"escalate_to_policy\" to escalate to a policy", i, actionType)
+			}
+		} else if actionType != "" && !d.HasChange(fmt.Sprintf("steps.%d.type", i)) {
+			// Validate the computed field only if the type is not changing
+			return fmt.Errorf("steps.%d: action_type can only be used with resolve_remove, time_branching, and metadata_branching steps", i)
 		}
 
 		// Validate instructions specific attributes

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -1397,3 +1397,251 @@ func TestResourcePolicyMetadataValueStateCleanup(t *testing.T) {
 		},
 	})
 }
+
+func TestResourcePolicyResolveRemove(t *testing.T) {
+	server := newResourceServer(t, "/api/v3/policies", "1")
+	defer server.Close()
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		ProviderFactories: map[string]func() (*schema.Provider, error){
+			"betteruptime": func() (*schema.Provider, error) {
+				return New(WithURL(server.URL)), nil
+			},
+		},
+		Steps: []resource.TestStep{
+			// Step 1 - create a policy with resolve_remove steps.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "this" {
+				  name = "Terraform - Resolve Remove"
+
+				  steps {
+					type        = "resolve_remove"
+					wait_before = 300
+					action_type = "resolve_incident"
+				  }
+				  steps {
+					type                = "resolve_remove"
+					wait_until_time     = "08:30"
+					wait_until_timezone = "UTC"
+					action_type         = "remove_incident"
+				  }
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("betteruptime_policy.this", "id"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.type", "resolve_remove"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.wait_before", "300"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.action_type", "resolve_incident"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.type", "resolve_remove"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.wait_until_time", "08:30"),
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.1.action_type", "remove_incident"),
+				),
+			},
+			// Step 2 - change the action type.
+			{
+				Config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "this" {
+				  name = "Terraform - Resolve Remove"
+
+				  steps {
+					type        = "resolve_remove"
+					wait_before = 300
+					action_type = "remove_incident"
+				  }
+				}
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("betteruptime_policy.this", "steps.0.action_type", "remove_incident"),
+				),
+			},
+			// Step 3 - import.
+			{
+				ResourceName:      "betteruptime_policy.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestResourcePolicyActionTypeValidation(t *testing.T) {
+	server := newResourceServer(t, "/api/v3/policies", "1")
+	defer server.Close()
+
+	cases := []struct {
+		name        string
+		config      string
+		expectError *regexp.Regexp
+	}{
+		{
+			name: "invalid - resolve_remove without action_type",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type        = "resolve_remove"
+						wait_before = 0
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0: action_type must be either resolve_incident or remove_incident for resolve_remove step`),
+		},
+		{
+			name: "invalid - resolve_remove with escalation action_type",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type        = "resolve_remove"
+						wait_before = 0
+						action_type = "escalate_to_policy"
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0: action_type must be either resolve_incident or remove_incident for resolve_remove step`),
+		},
+		{
+			name: "invalid - resolve_remove with policy_id",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type        = "resolve_remove"
+						wait_before = 0
+						action_type = "resolve_incident"
+						policy_id   = 123
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0: policy_id and policy_metadata_key cannot be used with resolve_remove step`),
+		},
+		{
+			name: "invalid - action_type on escalation step",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type        = "escalation"
+						wait_before = 0
+						urgency_id  = 123
+						action_type = "resolve_incident"
+						step_members { type = "current_on_call" }
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0: action_type can only be used with resolve_remove, time_branching, and metadata_branching steps`),
+		},
+		{
+			name: "invalid - escalate_to_policy without a policy",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type        = "time_branching"
+						wait_before = 0
+						timezone    = "UTC"
+						days        = ["mon"]
+						time_from   = "08:00"
+						time_to     = "22:00"
+						action_type = "escalate_to_policy"
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0: policy_id or policy_metadata_key must be set when action_type is escalate_to_policy`),
+		},
+		{
+			name: "invalid - resolve action combined with a policy",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type = "metadata_branching"
+						metadata_key = "environment"
+						metadata_value {
+							type  = "String"
+							value = "staging"
+						}
+						action_type = "resolve_incident"
+						policy_id   = 123
+					}
+				}
+			`,
+			expectError: regexp.MustCompile(`steps\.0: policy_id and policy_metadata_key cannot be used when action_type is resolve_incident`),
+		},
+		{
+			name: "valid - metadata branching resolving the incident",
+			config: `
+				provider "betteruptime" {
+					api_token = "foo"
+				}
+
+				resource "betteruptime_policy" "test" {
+					name = "Test Policy"
+					steps {
+						type = "metadata_branching"
+						metadata_key = "environment"
+						metadata_value {
+							type  = "String"
+							value = "staging"
+						}
+						action_type = "resolve_incident"
+					}
+				}
+			`,
+			expectError: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				IsUnitTest: true,
+				ProviderFactories: map[string]func() (*schema.Provider, error){
+					"betteruptime": func() (*schema.Provider, error) {
+						return New(WithURL(server.URL)), nil
+					},
+				},
+				Steps: []resource.TestStep{
+					{
+						Config:      tc.config,
+						ExpectError: tc.expectError,
+					},
+				},
+			})
+		})
+	}
+}


### PR DESCRIPTION
Closes BetterStackHQ/terraform-provider-better-uptime#225

Adds the `resolve_remove` step type to `betteruptime_policy`, together with a new step attribute `action_type`.

```hcl
steps {
  type        = "resolve_remove"
  wait_before = 3600
  action_type = "resolve_incident" # or "remove_incident"
}
```

* `action_type` is required on `resolve_remove` steps (`resolve_incident` or `remove_incident`), and optional on `time_branching`/`metadata_branching` steps (`escalate_to_policy`, `resolve_incident`, `remove_incident`, or `do_not_escalate`). When omitted on branching steps, the API keeps its current behavior - escalate when a policy is set, stop otherwise - and the attribute is `Optional + Computed`, so existing configs stay diff-free.
* Invalid combinations fail at plan time: a missing `action_type` on `resolve_remove`, `escalate_to_policy` without `policy_id`/`policy_metadata_key`, or a policy combined with a non-escalation action.
* The `examples/` policy config gains an auto-triage policy exercising the new step and a branching `action_type`; docs regenerated; `VERSION` and the examples constraint bumped to `0.21.13`.

The API-side support for writing `resolve_remove` steps is rolling out separately - E2E stays red until it's live.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)