### PR TITLE
U-9231 Remove the include_all_incidents_in_rss_feed status page argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOLANGCI_LINT := golangci-lint run --disable-all \
 	-E staticcheck \
 	-E typecheck \
 	-E unused
-VERSION := 0.21.12
+VERSION := 0.21.13
 .PHONY: test build
 
 help:

--- a/docs/resources/betteruptime_status_page.md
+++ b/docs/resources/betteruptime_status_page.md
@@ -46,11 +46,6 @@ resource "betteruptime_status_page" "this" {
   # Auto-generate downtime reports and keep the page out of search engines
   automatic_reports        = true
   hide_from_search_engines = true
-
-  # Keep the RSS feed to the status updates shown on the page. Set to true to also
-  # publish incidents nobody wrote an update for - pair it with automatic_reports = false,
-  # or the feed carries both the generated report and the raw incident for one outage
-  include_all_incidents_in_rss_feed = false
 }
 
 # Styled status page - branding, announcement and custom navigation
@@ -139,7 +134,6 @@ resource "betteruptime_status_page" "secure" {
 - `google_analytics_id` (String) Specify your own Google Analytics ID if you want to receive hits on your status page.
 - `hide_from_search_engines` (Boolean) Hide your status page from search engines.
 - `history` (Number) Number of days to display on the status page. Between 7 and 365 days.
-- `include_all_incidents_in_rss_feed` (Boolean) Publish incidents to the status page RSS feed, including ones you never report on the status page. Each resource's `mark_as_down_for` and `mark_as_degraded_for` rules and the status page's `min_incident_length` still apply.
 - `ip_allowlist` (List of String) List of IP addresses or CIDR ranges that are allowed to access the status page. Accepts IPv4, IPv6, CIDR ranges, and comments starting with `#`. To remove all IP restrictions, set to an empty list `[]`. This is a [billable feature](https://betterstack.com/pricing#status-pages).
 - `layout` (String) Choose usual vertical layout or space-saving horizontal layout. Only applicable when design: v2. Possible values: 'vertical', 'horizontal'.
 - `logo_url` (String) A direct link to your company's logo. The image should be under 20MB in size.

--- a/examples/resources/betteruptime_status_page/resource.tf
+++ b/examples/resources/betteruptime_status_page/resource.tf
@@ -31,11 +31,6 @@ resource "betteruptime_status_page" "this" {
   # Auto-generate downtime reports and keep the page out of search engines
   automatic_reports        = true
   hide_from_search_engines = true
-
-  # Keep the RSS feed to the status updates shown on the page. Set to true to also
-  # publish incidents nobody wrote an update for - pair it with automatic_reports = false,
-  # or the feed carries both the generated report and the raw incident for one outage
-  include_all_incidents_in_rss_feed = false
 }
 
 # Styled status page - branding, announcement and custom navigation

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -208,12 +208,6 @@ var statusPageSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Computed:    true,
 	},
-	"include_all_incidents_in_rss_feed": {
-		Description: "Publish incidents to the status page RSS feed, including ones you never report on the status page. Each resource's `mark_as_down_for` and `mark_as_degraded_for` rules and the status page's `min_incident_length` still apply.",
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Computed:    true,
-	},
 	"status_page_group_id": {
 		Description: "Set this attribute if you want to add this status page to a status page group.",
 		Type:        schema.TypeInt,
@@ -292,41 +286,40 @@ type navigationLink struct {
 }
 
 type statusPage struct {
-	History                      *int              `json:"history,omitempty"`
-	CompanyName                  *string           `json:"company_name,omitempty"`
-	CompanyURL                   *string           `json:"company_url,omitempty"`
-	ContactURL                   *string           `json:"contact_url,omitempty"`
-	LogoURL                      *string           `json:"logo_remote_url,omitempty"`
-	DarkLogoURL                  *string           `json:"dark_logo_remote_url,omitempty"`
-	Whitelabeled                 *bool             `json:"whitelabeled,omitempty"`
-	Timezone                     *string           `json:"timezone,omitempty"`
-	Subdomain                    *string           `json:"subdomain,omitempty"`
-	CustomDomain                 *string           `json:"custom_domain,omitempty"`
-	MinIncidentLength            *int              `json:"min_incident_length,omitempty"`
-	Subscribable                 *bool             `json:"subscribable,omitempty"`
-	Published                    *bool             `json:"published,omitempty"`
-	HideFromSearchEngines        *bool             `json:"hide_from_search_engines,omitempty"`
-	CustomCSS                    *string           `json:"custom_css,omitempty"`
-	CustomJavaScript             *string           `json:"custom_javascript,omitempty"`
-	GoogleAnalyticsID            *string           `json:"google_analytics_id,omitempty"`
-	Announcement                 *string           `json:"announcement,omitempty"`
-	AnnouncementEmbedVisible     *bool             `json:"announcement_embed_visible,omitempty"`
-	AnnouncementEmbedLink        *string           `json:"announcement_embed_link,omitempty"`
-	AnnouncementEmbedCSS         *string           `json:"announcement_embed_css,omitempty"`
-	PasswordEnabled              *bool             `json:"password_enabled,omitempty"`
-	Password                     *string           `json:"password,omitempty"`
-	RequireSSO                   *bool             `json:"require_sso,omitempty"`
-	AggregateState               *string           `json:"aggregate_state,omitempty"`
-	CreatedAt                    *string           `json:"created_at,omitempty"`
-	UpdatedAt                    *string           `json:"updated_at,omitempty"`
-	Design                       *string           `json:"design,omitempty"`
-	Theme                        *string           `json:"theme,omitempty"`
-	Layout                       *string           `json:"layout,omitempty"`
-	AutomaticReports             *bool             `json:"automatic_reports,omitempty"`
-	IncludeAllIncidentsInRSSFeed *bool             `json:"include_all_incidents_in_rss_feed,omitempty"`
-	StatusPageGroupID            *int              `json:"status_page_group_id,omitempty"`
-	NavigationLinks              *[]navigationLink `json:"navigation_links,omitempty"`
-	IPAllowlist                  *[]string         `json:"ip_allowlist,omitempty"`
+	History                  *int              `json:"history,omitempty"`
+	CompanyName              *string           `json:"company_name,omitempty"`
+	CompanyURL               *string           `json:"company_url,omitempty"`
+	ContactURL               *string           `json:"contact_url,omitempty"`
+	LogoURL                  *string           `json:"logo_remote_url,omitempty"`
+	DarkLogoURL              *string           `json:"dark_logo_remote_url,omitempty"`
+	Whitelabeled             *bool             `json:"whitelabeled,omitempty"`
+	Timezone                 *string           `json:"timezone,omitempty"`
+	Subdomain                *string           `json:"subdomain,omitempty"`
+	CustomDomain             *string           `json:"custom_domain,omitempty"`
+	MinIncidentLength        *int              `json:"min_incident_length,omitempty"`
+	Subscribable             *bool             `json:"subscribable,omitempty"`
+	Published                *bool             `json:"published,omitempty"`
+	HideFromSearchEngines    *bool             `json:"hide_from_search_engines,omitempty"`
+	CustomCSS                *string           `json:"custom_css,omitempty"`
+	CustomJavaScript         *string           `json:"custom_javascript,omitempty"`
+	GoogleAnalyticsID        *string           `json:"google_analytics_id,omitempty"`
+	Announcement             *string           `json:"announcement,omitempty"`
+	AnnouncementEmbedVisible *bool             `json:"announcement_embed_visible,omitempty"`
+	AnnouncementEmbedLink    *string           `json:"announcement_embed_link,omitempty"`
+	AnnouncementEmbedCSS     *string           `json:"announcement_embed_css,omitempty"`
+	PasswordEnabled          *bool             `json:"password_enabled,omitempty"`
+	Password                 *string           `json:"password,omitempty"`
+	RequireSSO               *bool             `json:"require_sso,omitempty"`
+	AggregateState           *string           `json:"aggregate_state,omitempty"`
+	CreatedAt                *string           `json:"created_at,omitempty"`
+	UpdatedAt                *string           `json:"updated_at,omitempty"`
+	Design                   *string           `json:"design,omitempty"`
+	Theme                    *string           `json:"theme,omitempty"`
+	Layout                   *string           `json:"layout,omitempty"`
+	AutomaticReports         *bool             `json:"automatic_reports,omitempty"`
+	StatusPageGroupID        *int              `json:"status_page_group_id,omitempty"`
+	NavigationLinks          *[]navigationLink `json:"navigation_links,omitempty"`
+	IPAllowlist              *[]string         `json:"ip_allowlist,omitempty"`
 }
 
 type statusPageHTTPResponse struct {
@@ -376,7 +369,6 @@ func statusPageRef(in *statusPage) []struct {
 		{k: "theme", v: &in.Theme},
 		{k: "layout", v: &in.Layout},
 		{k: "automatic_reports", v: &in.AutomaticReports},
-		{k: "include_all_incidents_in_rss_feed", v: &in.IncludeAllIncidentsInRSSFeed},
 		{k: "status_page_group_id", v: &in.StatusPageGroupID},
 		{k: "navigation_links", v: &in.NavigationLinks},
 		{k: "ip_allowlist", v: &in.IPAllowlist},

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -37,7 +37,6 @@ func TestResourceStatusPage(t *testing.T) {
 					subdomain         = "%s"
 					password          = "secret123"
 					automatic_reports = true
-					include_all_incidents_in_rss_feed = true
 					published         = true
 
 					navigation_links {
@@ -56,7 +55,6 @@ func TestResourceStatusPage(t *testing.T) {
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "timezone", "UTC"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "password", "secret123"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "automatic_reports", "true"),
-					resource.TestCheckResourceAttr("betteruptime_status_page.this", "include_all_incidents_in_rss_feed", "true"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "published", "true"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "navigation_links.0.text", "Example"),
 					resource.TestCheckResourceAttr("betteruptime_status_page.this", "navigation_links.0.href", "https://example.com"),


### PR DESCRIPTION
### Brief

Status page RSS feed no longer publish raw monitor incidents. The `include_all_incidents_in_rss_feed` argument no longer controls anything, so this reverts #231, which added it.


### ⚠️ Breaking change

Removing the argument from the schema means anyone who set it gets `Unsupported argument` and has to drop the line. It shipped in `v0.21.12` (tagged 2026-08-13).